### PR TITLE
fix: give user options precedence over defaults

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const defaultOptions: Options = {
 }
 
 function VitePluginComponents(options: Partial<Options> = {}): Plugin {
-  const resolvedOptions: Options = Object.assign({}, options, defaultOptions)
+  const resolvedOptions: Options = Object.assign({}, defaultOptions, options)
   const ctx: Context = new Context(resolvedOptions)
 
   return {


### PR DESCRIPTION
`Object.assign` writes to the target object in order of its parameters, so putting `options` before `defaultOptions` would mean you can't override the defaults. Probably just a small oversight.

Thanks for this tool by the way! Importing+exporting components in `<script setup>` feels so wrong haha.