### PR TITLE
feat: use parent directory as name for `index` components

### DIFF
--- a/src/fs/glob.ts
+++ b/src/fs/glob.ts
@@ -6,6 +6,18 @@ import { Context } from '../context'
 
 const debug = Debug('vite-plugin-components:glob')
 
+function getNameFromFilePath(filePath: string): string {
+  const parsedFilePath = path.parse(filePath)
+  if (parsedFilePath.name === 'index') {
+    const filePathSegments = filePath.split(path.sep)
+    const parentDirName = filePathSegments[filePathSegments.length - 2]
+    if (parentDirName) {
+      return parentDirName
+    }
+  }
+  return parsedFilePath.name
+}
+
 function toArray<T>(arr: T | T[]): T[] {
   if (Array.isArray(arr))
     return arr
@@ -52,7 +64,7 @@ export async function searchComponents(ctx: Context, force = false) {
 
       const nameSets = new Set<string>()
       const components = files
-        .map((f): ComponentsInfo => [path.parse(f).name, `/${f}`])
+        .map((f): ComponentsInfo => [getNameFromFilePath(f), `/${f}`])
         .filter(([name, path]) => {
           if (nameSets.has(name)) {
             console.warn(`[vite-plugin-components] component "${name}"(${path}) has naming conflicts with other components, ignored.`)


### PR DESCRIPTION
Currently the plugin resolves names as `/{NAME}.vue`. Although it's not always considered a best practice, Vue additionally supports importing components as `/{NAME}/index.vue`. This PR adds support for the latter so you don't end up with a bunch of warnings about duplicate name "index".

If this isn't the direction you want to go, no worries. Thanks!