### PR TITLE
feat(antdv): add AntDesignVueResolverOptions support exclude component

### DIFF
--- a/src/core/resolvers/antdv.ts
+++ b/src/core/resolvers/antdv.ts
@@ -152,6 +152,12 @@ const matchComponents: IMatcher[] = [
 
 export interface AntDesignVueResolverOptions {
   /**
+   * exclude components that do not require automatic import
+   *
+   * @default []
+   */
+  exclude?: string[]
+  /**
    * import style along with components
    *
    * @default 'css'
@@ -230,7 +236,7 @@ export function AntDesignVueResolver(options: AntDesignVueResolverOptions = {}):
       }
     }
 
-    if (name.match(/^A[A-Z]/)) {
+    if (name.match(/^A[A-Z]/) && !options?.exclude?.includes(name)) {
       const importName = name.slice(1)
       return {
         importName,


### PR DESCRIPTION
Hey, sometimes I need to exclude components that I don't need to automatically import because I registered a component globally with the same name as the component library, and if I don't exclude that component, the auto-imported component will overwrite the components that I registered globally