### PR TITLE
fix(prime-vue): remove 'Tooltip' from the component list

### DIFF
--- a/src/core/resolvers/prime-vue.ts
+++ b/src/core/resolvers/prime-vue.ts
@@ -89,7 +89,8 @@ const components = [
   // Toast must be registered globally in order for the toast service to work properly
   'ToggleButton',
   'Toolbar',
-  'Tooltip',
+  // 'Tooltip',
+  // Tooltip must be registered globally in order for the tooltip service to work properly
   'Tree',
   'TreeSelect',
   'TreeTable',


### PR DESCRIPTION
The tooltip is used as a directive, and it should be registered globally.