### PR TITLE
fixed auto import primevue components without ts support

### DIFF
--- a/src/core/resolvers/prime-vue.ts
+++ b/src/core/resolvers/prime-vue.ts
@@ -146,7 +146,7 @@ export function PrimeVueResolver(options: PrimeVueResolverOptions = {}): Compone
 
       if (components.includes(name)) {
         return {
-          path: `primevue/${name.toLowerCase()}/${name}.vue`,
+          path: `primevue/${name.toLowerCase()}`,
           sideEffects,
         }
       }


### PR DESCRIPTION
自动引入primevue时component.d.ts中的文件对组件的指向为.vue文件，导致导入的组件ts类型为any