### PR TITLE
feat(prime-vue): added prefix option

### DIFF
--- a/src/core/resolvers/prime-vue.ts
+++ b/src/core/resolvers/prime-vue.ts
@@ -119,6 +119,12 @@ export interface PrimeVueResolverOptions {
    * @default ''
    */
   importTheme?: string
+  /**
+   * prefix for components (e.g. 'P' to resolve Menu from PMenu)
+   *
+   * @default ''
+   */
+  prefix?: string
 }
 
 /**
@@ -142,6 +148,13 @@ export function PrimeVueResolver(options: PrimeVueResolverOptions = {}): Compone
         sideEffects.push(
           `primevue/resources/themes/${options.importTheme}/theme.css`,
         )
+      }
+
+      if (options.prefix) {
+        if (!name.startsWith(options.prefix)) {
+          return
+        }
+        name = name.substring(options.prefix.length)
       }
 
       if (components.includes(name)) {


### PR DESCRIPTION
Most UI Component libraries use prefix to allow fast distinguish between library and other components, even if PrimeVue doesn't use this practice, with this option we may use prefix for PrimeVue components.
Basically this is equivalent for:
```javascript
function PrimeVuePrefixResolver (options) {
  const resolver = PrimeVueResolver(options)
  const resolve = resolver.resolve
  resolver.resolve = (name) => {
    if (options.prefix) {
      if (!name.startsWith(options.prefix)) return
      return resolve(name.substring(options.prefix.length))
    }
  }
  return resolver
}
```
But I really believe this should be in upstream. Best practice for everyone.