### PR TITLE
fix: simply set `resolvedDirs` in case of globs option, close #246

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -34,6 +34,7 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
 
   if (resolved.globs) {
     resolved.globs = toArray(resolved.globs).map((glob: string) => slash(resolve(root, glob)))
+    resolved.resolvedDirs = []
   }
   else {
     const extsGlob = resolved.extensions.length === 1


### PR DESCRIPTION
Fix proposition for [#246](https://github.com/antfu/unplugin-vue-components/issues/246)