### PR TITLE
fix: source map

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -57,8 +57,8 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
     ? false
     : resolve(
       root,
-      typeof options.dts === 'string'
-        ? options.dts
+      typeof resolved.dts === 'string'
+        ? resolved.dts
         : 'components.d.ts',
     )
   resolved.root = root

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -53,7 +53,7 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
       throw new Error('[unplugin-vue-components] `extensions` option is required to search for components')
   }
 
-  resolved.dts = !options.dts
+  resolved.dts = !resolved.dts
     ? false
     : resolve(
       root,

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -36,7 +36,7 @@ export default createUnplugin<Options>((options = {}) => {
     vite: {
       configResolved(config) {
         ctx.setRoot(config.root)
-        ctx.sourcemap = config.build.sourcemap
+        ctx.sourcemap = true
 
         if (config.plugins.find(i => i.name === 'vite-plugin-vue2'))
           ctx.setTransformer('vue2')


### PR DESCRIPTION
Must return the sourcemap to vite, otherwise it would broke the sourcemap when debugging.
There is no default value for dts. It is always false if there is no config. But the document says its default value is `isPackageExists('typescript')`.