### PR TITLE
fix(tdesign): ignore config-provider/style

### DIFF
--- a/src/core/resolvers/tdesign.ts
+++ b/src/core/resolvers/tdesign.ts
@@ -27,6 +27,8 @@ function getSideEffects(importName: string, options: TDesignResolverOptions): Si
 
   if (!importStyle) return
 
+  if (fileName === "config-provider") return
+
   if (importStyle === 'less') return `tdesign-${library}/esm/${fileName}/style`
 
   return `tdesign-${library}/es/${fileName}/style`


### PR DESCRIPTION
使用 ```unplugin-vue-components``` 动态入组件时，使用
```<t-config-provider></t-config-provider>``` 
会由于 unplugin-vue-components 的原因 导入 es/config-provider/style 而出现404异常

> 这是由于  https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/tdesign.ts 的匹配规则是:  只要以t开头均视为有style的组件，但config-provider未提供style