### PR TITLE
docs(readme): fix confusion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ Supported Resolvers:
 
 ```ts
 // vite.config.js
-import ViteComponents, {
+import Components from 'unplugin-vue-components/vite'
+import {
   AntDesignVueResolver,
   ElementPlusResolver,
   VantResolver,


### PR DESCRIPTION
The ViteComponents variable is not used in the following code, and seems to be an older version of the code, where the Components variable is not imported