### PR TITLE
fix: add check for empty args[1]

### DIFF
--- a/src/core/transforms/directive/vue2.ts
+++ b/src/core/transforms/directive/vue2.ts
@@ -43,7 +43,7 @@ export default async function resolveVue2(code: string, s: MagicString): Promise
   for (const node of nodes) {
     const { callee, arguments: args } = node
     // _c(_, {})
-    if (callee.type !== 'Identifier' || callee.name !== '_c' || args[1].type !== 'ObjectExpression')
+    if (callee.type !== 'Identifier' || callee.name !== '_c' || args[1] == null || args[1].type !== 'ObjectExpression')
       continue
 
     // { directives: [] }


### PR DESCRIPTION
This causes runtime error:
`[plugin:unplugin-vue-components] Cannot read property 'type' of undefined`