### PR TITLE
fix(element-ui): unexpected handling of components

### DIFF
--- a/src/core/resolvers/element-ui.ts
+++ b/src/core/resolvers/element-ui.ts
@@ -46,7 +46,7 @@ export function ElementUiResolver(options: ElementUiResolverOptions = {}): Compo
   return {
     type: 'component',
     resolve: (name: string) => {
-      if (name.startsWith('El')) {
+      if (/^El[A-Z]/.test(name)) {
         const compName = name.slice(2)
         const partialName = kebabCase(compName)
         if (partialName === 'collapse-transition') {


### PR DESCRIPTION
This is actually an extension of this modification: https://github.com/antfu/unplugin-vue-components/commit/af8a7a0afd34e15034d9d39fc5622c74aaa9de81#diff-0b83587ef377a4d009821193cbfa7413273d34fddfdafc110049fe72eac51785R74-L24

Currently `ElementUiResolver` accidentally handles components with names like `ElegantComponent` just because their names start with `El`. I've been unable to determine the circumstances under which the commit mentioned above was made, but it appears that `ElementUiResolver` was missed at the time.

As an aside, in the future, perhaps options such as `exclude` will have the ability to be ported to `ElementUiResolver`, but that is not what this PR is intended to discuss.