### PR TITLE
fix(headless-ui): update regex

### DIFF
--- a/src/core/resolvers/headless-ui.ts
+++ b/src/core/resolvers/headless-ui.ts
@@ -68,7 +68,7 @@ export function HeadlessUiResolver(options: HeadlessUiResolverOptions = {}): Com
     type: 'component',
     resolve: (name: string) => {
       if (name.startsWith(prefix)) {
-        const componentName = name.replace(new RegExp(`\^\(${prefix}\)`), '')
+        const componentName = name.substring(prefix.length)
         if (components.includes(componentName)) {
           return {
             importName: componentName,


### PR DESCRIPTION
Change componentName clearing from prefix value in HeadlessUiResolver. Current Regex is not working at all.