### PR TITLE
feat: add a components api to allow manual detection in frameworks

### DIFF
--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -2,9 +2,9 @@ import { createUnplugin } from 'unplugin'
 import { createFilter } from '@rollup/pluginutils'
 import chokidar from 'chokidar'
 import type { ResolvedConfig, ViteDevServer } from 'vite'
-import type { Options } from '../types'
+import type { Options, ComponentsApi } from '../types'
 import { Context } from './context'
-import { shouldTransform } from './utils'
+import { shouldTransform, stringifyComponentImport } from './utils'
 
 export default createUnplugin<Options>((options = {}) => {
   const filter = createFilter(
@@ -13,9 +13,20 @@ export default createUnplugin<Options>((options = {}) => {
   )
   const ctx: Context = new Context(options)
 
+  const api: ComponentsApi = {
+    async findComponent(name, filename) {
+      return await ctx.findComponent(name, 'component', filename ? [filename] : [])
+    },
+    stringifyImport(info) {
+      return stringifyComponentImport(info, ctx)
+    },
+  }
+
   return {
     name: 'unplugin-vue-components',
     enforce: 'post',
+
+    api,
 
     transformInclude(id) {
       return filter(id)

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -2,7 +2,7 @@ import { createUnplugin } from 'unplugin'
 import { createFilter } from '@rollup/pluginutils'
 import chokidar from 'chokidar'
 import type { ResolvedConfig, ViteDevServer } from 'vite'
-import type { Options, ComponentsApi } from '../types'
+import type { Options, PublicPluginAPI } from '../types'
 import { Context } from './context'
 import { shouldTransform, stringifyComponentImport } from './utils'
 
@@ -13,7 +13,7 @@ export default createUnplugin<Options>((options = {}) => {
   )
   const ctx: Context = new Context(options)
 
-  const api: ComponentsApi = {
+  const api: PublicPluginAPI = {
     async findComponent(name, filename) {
       return await ctx.findComponent(name, 'component', filename ? [filename] : [])
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type Transformer = (code: string, id: string, path: string, query: Record
 
 export type SupportedTransformer = 'vue3' | 'vue2'
 
-export interface ComponentsApi {
+export interface PublicPluginAPI {
   /**
    * Resolves a component using the configured resolvers.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,17 @@ export type Transformer = (code: string, id: string, path: string, query: Record
 
 export type SupportedTransformer = 'vue3' | 'vue2'
 
+export interface ComponentsApi {
+  /**
+   * Resolves a component using the configured resolvers.
+   */
+  findComponent: (name: string, filename?: string) => Promise<ComponentInfo | undefined>
+  /**
+   * Obtain an import statement for a resolved component.
+   */
+  stringifyImport: (info: ComponentInfo) => string
+}
+
 /**
  * Plugin options.
  */

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'vite'
-import type { ComponentsApi, Options } from './types'
+import type { PublicPluginAPI, Options } from './types'
 import unplugin from '.'
 
-export default unplugin.vite as (options?: Options | undefined) => Plugin & { api: ComponentsApi }
+export default unplugin.vite as (options?: Options | undefined) => Plugin & { api: PublicPluginAPI }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'vite'
-import type { PublicPluginAPI, Options } from './types'
+import type { Options, PublicPluginAPI } from './types'
 import unplugin from '.'
 
 export default unplugin.vite as (options?: Options | undefined) => Plugin & { api: PublicPluginAPI }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,3 +1,5 @@
+import type { Plugin } from 'vite'
+import type { ComponentsApi, Options } from './types'
 import unplugin from '.'
 
-export default unplugin.vite
+export default unplugin.vite as (options?: Options | undefined) => Plugin & { api: ComponentsApi }


### PR DESCRIPTION
### Description 📖 

This pull requests adds an `api` to `unplugin-vue-components`, allowing it to be used programmatically.

The benefit of exposing an API is that frameworks can easily integrate with this plugin and leverage any component resolvers that the user has already configured, providing a consistent DX.

### Examples 📝

[îles](https://iles-docs.netlify.app/) uses this api to [resolve components](https://github.com/ElMassimo/iles/blob/main/packages/iles/src/node/plugin/wrap.ts#L113-L115) inside islands.

It also can [conditionally inject imports](https://github.com/ElMassimo/iles/blob/main/packages/iles/src/node/plugin/wrap.ts#L79) based on whether the islands are SSR-compatible. This is an advanced use case that wouldn't be possible if the user imported components manually.