### PR TITLE
feat(resolver): add Vuetify 3 Beta resolver

### DIFF
--- a/src/core/resolvers/vuetify.ts
+++ b/src/core/resolvers/vuetify.ts
@@ -14,3 +14,18 @@ export function VuetifyResolver(): ComponentResolver {
     },
   }
 }
+
+/**
+ * Resolver for Vuetify 3 Beta
+ *
+ * @link https://github.com/vuetifyjs/vuetify
+ */
+export function Vuetify3BetaResolver(): ComponentResolver {
+  return {
+    type: 'component',
+    resolve: (name: string) => {
+      if (name.match(/^V[A-Z]/))
+        return { importName: name, path: 'vuetify/components' }
+    },
+  }
+}

--- a/src/core/resolvers/vuetify.ts
+++ b/src/core/resolvers/vuetify.ts
@@ -20,7 +20,7 @@ export function VuetifyResolver(): ComponentResolver {
  *
  * @link https://github.com/vuetifyjs/vuetify
  */
-export function Vuetify3BetaResolver(): ComponentResolver {
+export function Vuetify3Resolver(): ComponentResolver {
   return {
     type: 'component',
     resolve: (name: string) => {


### PR DESCRIPTION
added a second resolver under vuetify for the new Vue3/composition-api compatible version of vuetify now in beta, which uses a new import path for components.

After making this, I thought to look at the other resolvers and I didn't see other ones with multiple implementations exported, so I'm thinking the way to do this would be to instead give the resolver an optional parameter to set the version to the v3 beta. I've got that ready in my local version, and am happy to update it to that upon request. 

closes #200