### PR TITLE
feat(arco): new option sideEffect

### DIFF
--- a/src/core/resolvers/arco.ts
+++ b/src/core/resolvers/arco.ts
@@ -143,6 +143,12 @@ export interface ArcoResolverOptions {
    * @default false
    */
   resolveIcons?: boolean
+  /**
+   * disable style import
+   *
+   * @default false
+   */
+  disableSideEffect?: false
 }
 
 /**
@@ -170,11 +176,14 @@ export function ArcoResolver(
         const importStyle = options.importStyle ?? 'css'
 
         const importName = name.slice(1)
-        return {
+        const config = {
           importName,
           path: '@arco-design/web-vue',
-          sideEffects: getComponentStyleDir(importName, importStyle),
         }
+        if (!options.disableSideEffect) {
+          (config as any).sideEffects = getComponentStyleDir(importName, importStyle)
+        }
+        return config
       }
     },
   }

--- a/src/core/resolvers/arco.ts
+++ b/src/core/resolvers/arco.ts
@@ -144,11 +144,11 @@ export interface ArcoResolverOptions {
    */
   resolveIcons?: boolean
   /**
-   * disable style import
+   * Control style automatic import
    *
-   * @default false
+   * @default true
    */
-  disableSideEffect?: false
+  sideEffect?: boolean
 }
 
 /**
@@ -180,7 +180,7 @@ export function ArcoResolver(
           importName,
           path: '@arco-design/web-vue',
         }
-        if (!options.disableSideEffect) {
+        if (options.sideEffect !== false) {
           (config as any).sideEffects = getComponentStyleDir(importName, importStyle)
         }
         return config


### PR DESCRIPTION
https://github.com/arco-design/arco-design-vue/issues/864

添加一个类型正确的配置（importStyle可以赋值空字符串绕过，但类型不符合），可以让按需引入组件时，不引入样式文件，以达到不覆盖Arco主题包的目的。这个属性如果不使用将不会对原来的配置有任何影响。