### PR TITLE
fix(quasar): replace require() by readFileSync() in QuasarResolver

### DIFF
--- a/src/core/resolvers/quasar.ts
+++ b/src/core/resolvers/quasar.ts
@@ -9,12 +9,12 @@ const { readFile } = promises
  *
  * @link https://github.com/quasarframework/quasar
  */
-export function QuasarResolver (): ComponentResolver {
+export function QuasarResolver(): ComponentResolver {
   let components: unknown[] = []
 
   return {
     type: 'component',
-    resolve: async (name: string) => {
+    resolve: async(name: string) => {
       if (!components.length) {
         const quasarApiListPath = resolveModule('quasar/dist/transforms/api-list.json')
         if (quasarApiListPath) components = JSON.parse((await readFile(quasarApiListPath)).toString())

--- a/src/core/resolvers/quasar.ts
+++ b/src/core/resolvers/quasar.ts
@@ -1,8 +1,7 @@
 
-import { promises } from 'fs'
+import { promises as fs } from 'fs'
 import { resolveModule } from 'local-pkg'
 import type { ComponentResolver } from '../../types'
-const { readFile } = promises
 
 /**
  * Resolver for Quasar
@@ -17,7 +16,8 @@ export function QuasarResolver(): ComponentResolver {
     resolve: async(name: string) => {
       if (!components.length) {
         const quasarApiListPath = resolveModule('quasar/dist/transforms/api-list.json')
-        if (quasarApiListPath) components = JSON.parse((await readFile(quasarApiListPath)).toString())
+        if (quasarApiListPath)
+          components = JSON.parse(await fs.readFile(quasarApiListPath, 'utf-8'))
       }
 
       if (components.includes(name))

--- a/src/core/resolvers/quasar.ts
+++ b/src/core/resolvers/quasar.ts
@@ -1,7 +1,9 @@
 
-import type { ComponentResolver } from '../../types'
-import { readFileSync } from 'fs'
+import { promises } from 'fs'
 import { resolveModule } from 'local-pkg'
+import type { ComponentResolver } from '../../types'
+const { readFile } = promises
+
 /**
  * Resolver for Quasar
  *
@@ -15,7 +17,7 @@ export function QuasarResolver (): ComponentResolver {
     resolve: async (name: string) => {
       if (!components.length) {
         const quasarApiListPath = resolveModule('quasar/dist/transforms/api-list.json')
-        if (quasarApiListPath) components = JSON.parse(readFileSync(quasarApiListPath).toString())
+        if (quasarApiListPath) components = JSON.parse((await readFile(quasarApiListPath)).toString())
       }
 
       if (components.includes(name))

--- a/src/core/resolvers/quasar.ts
+++ b/src/core/resolvers/quasar.ts
@@ -1,22 +1,21 @@
 
 import type { ComponentResolver } from '../../types'
-
+import { readFileSync } from 'fs'
+import { resolveModule } from 'local-pkg'
 /**
  * Resolver for Quasar
  *
  * @link https://github.com/quasarframework/quasar
  */
-export function QuasarResolver(): ComponentResolver {
+export function QuasarResolver (): ComponentResolver {
+  let components: unknown[] = []
+
   return {
     type: 'component',
-    resolve: (name: string) => {
-      let components = []
-
-      try {
-        /* eslint-disable @typescript-eslint/no-var-requires */
-        components = require('quasar/dist/transforms/api-list.json')
-      }
-      catch (e) {
+    resolve: async (name: string) => {
+      if (!components.length) {
+        const quasarApiListPath = resolveModule('quasar/dist/transforms/api-list.json')
+        if (quasarApiListPath) components = JSON.parse(readFileSync(quasarApiListPath).toString())
       }
 
       if (components.includes(name))


### PR DESCRIPTION
When using `"type": "module"`, QuasarResolver leads to `require() is not defined` errors.
Because `import()` of JSON files is not supported yet, the solution is to use readFileSync for now (and resolve the path with `local-pkg`).

This might also solve #332