### PR TITLE
fix(arco): add component `DescriptionsItem` support

### DIFF
--- a/src/core/resolvers/arco.ts
+++ b/src/core/resolvers/arco.ts
@@ -114,6 +114,11 @@ const matchComponents = [
     pattern: /^(TypographyParagraph|TypographyTitle|TypographyText)$/,
     componentDir: 'typography',
   },
+
+  {
+    pattern: /^DescriptionsItem$/,
+    componentDir: "descriptions"
+  },
 ]
 
 function getComponentStyleDir(importName: string, importStyle: boolean | 'css' | 'less') {


### PR DESCRIPTION
添加以 slot 方式使用 `a-descriptions-item` 组件支持。
```vue
<a-descriptions title="title">
  <a-descriptions-item label="foo">bar</a-descriptions-item>
</a-descriptions>
```

https://github.com/arco-design/arco-design-vue/tree/main/packages/web-vue/components/descriptions

arco 组件库版本 `v2.21.1`（2022-03-25）