### PR TITLE
fix: vantResolver partial name

### DIFF
--- a/src/core/resolvers/vant.ts
+++ b/src/core/resolvers/vant.ts
@@ -36,8 +36,9 @@ export function VantResolver(options: VantResolverOptions = {}): ComponentResolv
   return {
     type: 'component',
     resolve: (name: string) => {
-      if (name.startsWith('Van')) {
-        const partialName = name.slice(3)
+      if (name.startsWith('Vant')) {
+        // 'tName' would be a mistake
+        const partialName = name.slice(4)
         return {
           name: partialName,
           from: `vant/${moduleType}`,

--- a/src/core/resolvers/vant.ts
+++ b/src/core/resolvers/vant.ts
@@ -37,7 +37,6 @@ export function VantResolver(options: VantResolverOptions = {}): ComponentResolv
     type: 'component',
     resolve: (name: string) => {
       if (name.startsWith('Vant')) {
-        // 'tName' would be a mistake
         const partialName = name.slice(4)
         return {
           name: partialName,


### PR DESCRIPTION
VantResolver would make a mistake in generating component name
just like
`VantButton: typeof import('vant/es')['tButton']`
`"vant/es/t-button/style/index"` this file does not exist
maybe that can help
```
if (name.startsWith('Vant')) {
    const partialName = name.slice(4);
    return {
        /*... */
    };
}
``` 