### PR TITLE
revert: vantResolver partial name

### DIFF
--- a/src/core/resolvers/vant.ts
+++ b/src/core/resolvers/vant.ts
@@ -36,8 +36,8 @@ export function VantResolver(options: VantResolverOptions = {}): ComponentResolv
   return {
     type: 'component',
     resolve: (name: string) => {
-      if (name.startsWith('Vant')) {
-        const partialName = name.slice(4)
+      if (name.startsWith('Van')) {
+        const partialName = name.slice(3)
         return {
           name: partialName,
           from: `vant/${moduleType}`,


### PR DESCRIPTION
I found that I use `<VantButton>` to code. But the 'Vant' is not the correct prefix.
This plugin generated codes like that `VantButton: typeof import('vant/es')['tButton']`.
I'm so sorry for that mistake.
😣