### PR TITLE
fix(antdv): variable.less not loaded when sets root-entry-name to variable

### DIFF
--- a/src/core/resolvers/antdv.ts
+++ b/src/core/resolvers/antdv.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'path'
 import type { ComponentResolver, SideEffectsInfo } from '../../types'
 import { kebabCase } from '../utils'
 interface IMatcher {
@@ -222,8 +221,13 @@ function getSideEffects(compName: string, options: AntDesignVueResolverOptions):
   const lib = options.cjs ? 'lib' : 'es'
 
   if (importStyle === 'less' || importLess) {
-    const styleDir = getStyleDir(compName)
-    return `ant-design-vue/${lib}/${styleDir}/style`
+    if (compName === 'Col' || compName === 'Row') {
+      return `ant-design-vue/${lib}/style/index.less`
+    }
+    else {
+      const styleDir = getStyleDir(compName)
+      return `ant-design-vue/${lib}/${styleDir}/style/index.less`
+    }
   }
   else {
     const styleDir = getStyleDir(compName)


### PR DESCRIPTION
```js
  css: {
    preprocessorOptions: {
      less: {
        javascriptEnabled: true,
        modifyVars: {
          'root-entry-name': 'variable'
        }
      }
    }
  },
```

Specifying root-entry-name as variable does not take effect.

`ant-design-vue/${lib}/${styleDir}/style/index.js` always loads default.less instead of following root-entry-name changes, 
so we need to specify load less

