### PR TITLE
perf!: use estree-walker

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Components({
   // auto import for directives
   // default: `true` for Vue 3, `false` for Vue 2
   // Babel is needed to do the transformation for Vue 2, it's disabled by default for performance concerns.
-  // To install Babel, run: `npm install -D @babel/parser @babel/traverse`
+  // To install Babel, run: `npm install -D @babel/parser estree-walker`
   directives: true,
 
   // Transform path before resolving

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Components({
   // auto import for directives
   // default: `true` for Vue 3, `false` for Vue 2
   // Babel is needed to do the transformation for Vue 2, it's disabled by default for performance concerns.
-  // To install Babel, run: `npm install -D @babel/parser estree-walker`
+  // To install Babel, run: `npm install -D @babel/parser`
   directives: true,
 
   // Transform path before resolving

--- a/package.json
+++ b/package.json
@@ -76,14 +76,10 @@
   },
   "peerDependencies": {
     "@babel/parser": "^7.15.8",
-    "estree-walker": "^2.0.2",
     "vue": "2 || 3"
   },
   "peerDependenciesMeta": {
     "@babel/parser": {
-      "optional": true
-    },
-    "estree-walker": {
       "optional": true
     }
   },
@@ -113,7 +109,7 @@
     "element-plus": "^2.2.5",
     "eslint": "^8.17.0",
     "esno": "^0.16.3",
-    "estree-walker": "^2.0.2",
+    "estree-walker": "^3.0.1",
     "pathe": "^0.3.0",
     "rollup": "^2.75.6",
     "tsup": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -76,14 +76,14 @@
   },
   "peerDependencies": {
     "@babel/parser": "^7.15.8",
-    "@babel/traverse": "^7.15.4",
+    "estree-walker": "^2.0.2",
     "vue": "2 || 3"
   },
   "peerDependenciesMeta": {
     "@babel/parser": {
       "optional": true
     },
-    "@babel/traverse": {
+    "estree-walker": {
       "optional": true
     }
   },
@@ -102,7 +102,6 @@
   "devDependencies": {
     "@antfu/eslint-config": "^0.25.1",
     "@babel/parser": "^7.18.5",
-    "@babel/traverse": "^7.18.5",
     "@babel/types": "^7.18.4",
     "@types/debug": "^4.1.7",
     "@types/minimatch": "^3.0.5",
@@ -114,6 +113,7 @@
     "element-plus": "^2.2.5",
     "eslint": "^8.17.0",
     "esno": "^0.16.3",
+    "estree-walker": "^2.0.2",
     "pathe": "^0.3.0",
     "rollup": "^2.75.6",
     "tsup": "^6.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ importers:
       '@antfu/eslint-config': ^0.25.1
       '@antfu/utils': ^0.5.2
       '@babel/parser': ^7.18.5
-      '@babel/traverse': ^7.18.5
       '@babel/types': ^7.18.4
       '@rollup/pluginutils': ^4.2.1
       '@types/debug': ^4.1.7
@@ -22,6 +21,7 @@ importers:
       element-plus: ^2.2.5
       eslint: ^8.17.0
       esno: ^0.16.3
+      estree-walker: ^2.0.2
       fast-glob: ^3.2.11
       local-pkg: ^0.4.1
       magic-string: ^0.26.2
@@ -49,7 +49,6 @@ importers:
     devDependencies:
       '@antfu/eslint-config': 0.25.1_ud6rd4xtew5bv4yhvkvu24pzm4
       '@babel/parser': 7.18.5
-      '@babel/traverse': 7.18.5
       '@babel/types': 7.18.4
       '@types/debug': 4.1.7
       '@types/minimatch': 3.0.5
@@ -61,6 +60,7 @@ importers:
       element-plus: 2.2.5_vue@3.2.37
       eslint: 8.17.0
       esno: 0.16.3
+      estree-walker: 2.0.2
       pathe: 0.3.0
       rollup: 2.75.6
       tsup: 6.1.2_typescript@4.7.3
@@ -2763,7 +2763,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.5
       '@vue/babel-preset-app': 5.0.4_vue@3.2.37
-      '@vue/cli-service': 5.0.4
+      '@vue/cli-service': 5.0.4_@babel+core@7.18.5
       '@vue/cli-shared-utils': 5.0.4
       babel-loader: 8.2.3_o7sdmn6una4l5qvkwlgctgywly
       thread-loader: 3.0.4_webpack@5.70.0
@@ -2783,7 +2783,7 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
     dependencies:
-      '@vue/cli-service': 5.0.4
+      '@vue/cli-service': 5.0.4_@babel+core@7.18.5
       '@vue/cli-shared-utils': 5.0.4
     transitivePeerDependencies:
       - encoding
@@ -2831,7 +2831,7 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
     dependencies:
-      '@vue/cli-service': 5.0.4
+      '@vue/cli-service': 5.0.4_@babel+core@7.18.5
     dev: true
 
   /@vue/cli-service/5.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
       element-plus: ^2.2.5
       eslint: ^8.17.0
       esno: ^0.16.3
-      estree-walker: ^2.0.2
+      estree-walker: ^3.0.1
       fast-glob: ^3.2.11
       local-pkg: ^0.4.1
       magic-string: ^0.26.2
@@ -60,7 +60,7 @@ importers:
       element-plus: 2.2.5_vue@3.2.37
       eslint: 8.17.0
       esno: 0.16.3
-      estree-walker: 2.0.2
+      estree-walker: 3.0.1
       pathe: 0.3.0
       rollup: 2.75.6
       tsup: 6.1.2_typescript@4.7.3
@@ -6322,6 +6322,10 @@ packages:
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  /estree-walker/3.0.1:
+    resolution: {integrity: sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==}
+    dev: true
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}

--- a/src/core/transforms/directive/vue2.ts
+++ b/src/core/transforms/directive/vue2.ts
@@ -24,8 +24,8 @@ const getRenderFnStart = (ast: ParseResult<File>): number => {
 }
 
 export default async function resolveVue2(code: string, s: MagicString): Promise<ResolveResult[]> {
-  if (!isPackageExists('@babel/parser') || !isPackageExists('estree-walker'))
-    throw new Error('[unplugin-vue-components:directive] To use Vue 2 directive you will need to install Babel first: "npm install -D @babel/parser estree-walker"')
+  if (!isPackageExists('@babel/parser'))
+    throw new Error('[unplugin-vue-components:directive] To use Vue 2 directive you will need to install Babel first: "npm install -D @babel/parser"')
 
   const { parse } = await importModule<typeof import('@babel/parser')>('@babel/parser')
   const ast = parse(code, {
@@ -33,7 +33,7 @@ export default async function resolveVue2(code: string, s: MagicString): Promise
   })
 
   const nodes: CallExpression[] = []
-  const { walk } = await importModule<typeof import('estree-walker')>('estree-walker')
+  const { walk } = await import('estree-walker')
   walk(ast.program as any, {
     enter(node: any) {
       if ((node as Node).type === 'CallExpression')

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,7 @@ export interface Options {
    * default: `true` for Vue 3, `false` for Vue 2
    *
    * Babel is needed to do the transformation for Vue 2, it's disabled by default for performance concerns.
-   * To install Babel, run: `npm install -D @babel/parser estree-walker`
+   * To install Babel, run: `npm install -D @babel/parser`
    * @default undefined
    */
   directives?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,7 @@ export interface Options {
    * default: `true` for Vue 3, `false` for Vue 2
    *
    * Babel is needed to do the transformation for Vue 2, it's disabled by default for performance concerns.
-   * To install Babel, run: `npm install -D @babel/parser @babel/traverse`
+   * To install Babel, run: `npm install -D @babel/parser estree-walker`
    * @default undefined
    */
   directives?: boolean


### PR DESCRIPTION
- use `estree-walker`.

`estree-walker` is faster and simpler than `@babel/traverse`.

FYI: [a simple benchmark](https://github.com/sxzz/unplugin-jsx-string/releases/tag/v0.3.0) in my plugin.

~~P.S. Please keep `estree-walker` 2.x, cause `estree-walker@3` is a ESM-only package.~~