### PR TITLE
fix: compiler.watcher undefined

### DIFF
--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -73,7 +73,7 @@ export default createUnplugin<Options>((options = {}) => {
       let watcher: Watching
       let fileDepQueue: { path: string; type: 'unlink' | 'add' }[] = []
       compiler.hooks.watchRun.tap(PLUGIN_NAME, () => {
-        // ensure watcher is ready
+        // ensure watcher is ready(supported since webpack@5.0.0-rc.1)
         if (!watcher && compiler.watching) {
           watcher = compiler.watching
           ctx.setupWatcherWebpack(chokidar.watch(ctx.options.globs), (path: string, type: 'unlink' | 'add') => {


### PR DESCRIPTION
some scenes, `compile.mode` is `development`, but `compiler.watcher` is undefined. For example:
1. `webpack.config.js` set mode `development` but `watch: false`.
2. `plugin` is executed earlier than `new Watching`, that maybe lead file changed but `Watching` have not been instantiated.
3. `compiler.watching` is supported since `webpack@5.0.0-rc.1`

close #436