### PR TITLE
fix: lose components types of components.d.ts

### DIFF
--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs'
 import { createUnplugin } from 'unplugin'
 import { createFilter } from '@rollup/pluginutils'
 import chokidar from 'chokidar'
@@ -56,9 +57,10 @@ export default createUnplugin<Options>((options = {}) => {
         if (config.plugins.find(i => i.name === 'vite-plugin-vue2'))
           ctx.setTransformer('vue2')
 
-        if (options.dts) {
+        if (ctx.options.dts) {
           ctx.searchGlob()
-          ctx.generateDeclaration()
+          if (!existsSync(ctx.options.dts))
+            ctx.generateDeclaration()
         }
 
         if (config.build.watch && config.command === 'build')


### PR DESCRIPTION
fix #403
fix #419

1. The `options.dts` is unresolved, if the user not setting `dts` then will return `undefined` (not default value `true`), so must be use from the resolved option `ctx.options.dts`.
2. The `ctx.generateDeclaration()` can't resolve the UI components (get from resolvers) on first call on startup dev server, whether UI components in the `components.d.ts` exists or not, will be removed on startup dev server.

This PR changes to generate .d.ts file on startup server if `ctx.options.dts` is true and the file (like `components.d.ts`) exists.

(Of course, `components.d.ts` will still be updated normally when adding, updating files or trigger `transform` hook.)

---

### No fix:

`components.d.ts` (before startup server):

```ts
declare module '@vue/runtime-core' {
  export interface GlobalComponents {
    ComponentA: typeof import('./src/components/ComponentA.vue')['default']
    VanRate: typeof import('vant/es')['Rate']
  }

}
```

Start dev/preview server if no setting `options.dts`:

```ts
declare module '@vue/runtime-core' {
  export interface GlobalComponents {
    ComponentA: typeof import('./src/components/ComponentA.vue')['default']
    VanRate: typeof import('vant/es')['Rate']
  }

}
```

Start dev/preview server if setting `options.dts` to true:

> **Warning**: missing `VanRate` (and other UI components) component type, the #403, #419 both is this status.

```ts
declare module '@vue/runtime-core' {
  export interface GlobalComponents {
    ComponentA: typeof import('./src/components/ComponentA.vue')['default']
  }

}
```

### Apply PR (fixed):

`components.d.ts` (before startup server):

```ts
declare module '@vue/runtime-core' {
  export interface GlobalComponents {
    ComponentA: typeof import('./src/components/ComponentA.vue')['default']
    VanRate: typeof import('vant/es')['Rate']
  }

}
```

Start dev/preview server if no setting `options.dts`:

```ts
declare module '@vue/runtime-core' {
  export interface GlobalComponents {
    ComponentA: typeof import('./src/components/ComponentA.vue')['default']
    VanRate: typeof import('vant/es')['Rate']
  }

}
```

Start dev/preview server if setting `options.dts` to true:

```ts
declare module '@vue/runtime-core' {
  export interface GlobalComponents {
    ComponentA: typeof import('./src/components/ComponentA.vue')['default']
    VanRate: typeof import('vant/es')['Rate']
  }

}
```
