### PR TITLE
fix: missing `collapseSamePrefixes` option default value

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -11,6 +11,7 @@ export const defaultOptions: Omit<Required<Options>, 'include' | 'exclude' | 'tr
   dts: isPackageExists('typescript'),
 
   directoryAsNamespace: false,
+  collapseSamePrefixes: false,
   globalNamespaces: [],
 
   resolvers: [],


### PR DESCRIPTION
In PR #409 forgot to add `collapseSamePrefixes` option default value, so the editor has TS error:

![sd2g1s5fe4](https://user-images.githubusercontent.com/38133356/177369459-c832377c-1f19-4de5-a208-bf3c33e01fa9.jpg)

