### PR TITLE
chore: fix wrong component path in components.d.ts of example

### DIFF
--- a/examples/vite-vue3/components.d.ts
+++ b/examples/vite-vue3/components.d.ts
@@ -22,7 +22,7 @@ declare module '@vue/runtime-core' {
     IRiApps2Line: typeof import('~icons/ri/apps2-line')['default']
     MarkdownA: typeof import('./src/components/MarkdownA.md')['default']
     MarkdownB: typeof import('./src/components/MarkdownB.md')['default']
-    MyCustom: typeof import('./../../../../../src/CustomResolved.vue')['default']
+    MyCustom: typeof import('./src/CustomResolved.vue')['default']
     Recursive: typeof import('./src/components/Recursive.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -30,7 +30,7 @@ const config: UserConfig = {
       resolvers: [
         (name) => {
           if (name === 'MyCustom')
-            return '/src/CustomResolved.vue'
+            return path.resolve(__dirname, 'src/CustomResolved.vue').replaceAll('\\', '/')
         },
         VantResolver(),
         IconsResolver({


### PR DESCRIPTION
Fix path in `examples/vite-vue3/components.d.ts` (it is regenerated):
```diff
-   MyCustom: typeof import('./../../../../../src/CustomResolved.vue')['default']
+   MyCustom: typeof import('./src/CustomResolved.vue')['default']
```