### PR TITLE
fix(element-plus): handling components without styles

### DIFF
--- a/src/core/resolvers/element-plus.ts
+++ b/src/core/resolvers/element-plus.ts
@@ -145,6 +145,8 @@ function resolveDirective(name: string, options: ElementPlusResolverOptionsResol
   }
 }
 
+const noStylesComponent = ['ElAutoResizer']
+
 /**
  * Resolver for Element Plus
  *
@@ -178,7 +180,11 @@ export function ElementPlusResolver(
     {
       type: 'component',
       resolve: async (name: string) => {
-        return resolveComponent(name, await resolveOptions())
+        const options = await resolveOptions()
+
+        if (noStylesComponent.includes(name))
+          return resolveComponent(name, { ...options, importStyle: false })
+        else return resolveComponent(name, options)
       },
     },
     {


### PR DESCRIPTION
### Description

Element Plus can contain components without css files. There seems to be only one such component right now, `ElAutoResizer`. Now it comes to an error of loading un-existed styles file.
This PR adds a list of components without styles that can be updated later, and toggles the `importStyle` flag to false for them.

### Linked Issues

https://github.com/element-plus/element-plus/issues/7933

