### PR TITLE
feat(bootstrap-vue): add support for aliases and directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,14 @@ Supported Resolvers:
 - [Inkline](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/inkline.ts)
 - [Naive UI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/naive-ui.ts)
 - [Prime Vue](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/prime-vue.ts)
+- [Quasar](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/quasar.ts)
+- [TDesign](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/tdesign.ts)
 - [Vant](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/vant.ts)
-- [VEUI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/veui.ts)
 - [Varlet UI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/varlet-ui.ts)
+- [VEUI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/veui.ts)
 - [View UI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/view-ui.ts)
 - [Vuetify](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/vuetify.ts)
 - [VueUse Components](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/vueuse.ts)
-- [Quasar](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/quasar.ts)
-- [TDesign](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/tdesign.ts)
 
 ```ts
 // vite.config.js

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Supported Resolvers:
 
 - [Ant Design Vue](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/antdv.ts)
 - [Arco Design Vue](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/arco.ts)
+- [BootstrapVue](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/bootstrap-vue.ts)
 - [Element Plus](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/element-plus.ts)
 - [Element UI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/element-ui.ts)
 - [Headless UI](https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/headless-ui.ts)

--- a/src/core/resolvers/bootstrap-vue.ts
+++ b/src/core/resolvers/bootstrap-vue.ts
@@ -72,7 +72,7 @@ export function BootstrapVueResolver(_options: BootstrapVueResolverOptions = {})
     resolvers.push({
       type: 'directive',
       resolve: (name) => {
-        if (options.directives && name.match(/^B[A-Z]/)) {
+        if (name.match(/^B[A-Z]/)) {
           return {
             name: `V${name}`,
             from: 'bootstrap-vue',

--- a/src/core/resolvers/bootstrap-vue.ts
+++ b/src/core/resolvers/bootstrap-vue.ts
@@ -1,16 +1,86 @@
 import type { ComponentResolver } from '../../types'
 
+export interface BootstrapVueResolverOptions {
+  /**
+   * Auto import for directives.
+   *
+   * @default true
+   */
+  directives?: boolean
+}
+
+const COMPONENT_ALIASES: Record<string, string> = {
+  BBtn: 'BButton',
+  BBtnClose: 'BButtonClose',
+  BBtnGroup: 'BButtonGroup',
+  BBtnToolbar: 'BButtonToolbar',
+  BCheck: 'BFormCheckbox',
+  BCheckbox: 'BFormCheckbox',
+  BCheckboxGroup: 'BFormCheckboxGroup',
+  BCheckGroup: 'BFormCheckboxGroup',
+  BDatalist: 'BFormDatalist',
+  BDd: 'BDropdown',
+  BDdDivider: 'BDropdownDivider',
+  BDdForm: 'BDropdownForm',
+  BDdGroup: 'BDropdownGroup',
+  BDdHeader: 'BDropdownHeader',
+  BDdItem: 'BDropdownItem',
+  BDdItemButton: 'BDropdownItemButton',
+  BDdItemBtn: 'BDropdownItemButton',
+  BDdText: 'BDropdownText',
+  BDropdownItemBtn: 'BDropdownItemButton',
+  BFile: 'BFormFile',
+  BFormDatepicker: 'BDatepicker',
+  BInput: 'BFormInput',
+  BNavDd: 'BNavItemDropdown',
+  BNavDropdown: 'BNavItemDropdown',
+  BNavItemDd: 'BNavItemDropdown',
+  BNavToggle: 'BNavbarToggle',
+  BRadio: 'BFormRadio',
+  BRadioGroup: 'BFormRadioGroup',
+  BRating: 'BFormRating',
+  BSelect: 'BFormSelect',
+  BSelectOption: 'BFormSelectOption',
+  BSelectOptionGroup: 'BFormSelectOptionGroup',
+  BSpinbutton: 'BFormSpinbutton',
+  BTag: 'BFormTag',
+  BTags: 'BFormTags',
+  BTextarea: 'BFormTextarea',
+  BTimepicker: 'BFormTimepicker',
+}
+
 /**
  * Resolver for BootstrapVue
  *
  * @link https://github.com/bootstrap-vue/bootstrap-vue
  */
-export function BootstrapVueResolver(): ComponentResolver {
-  return {
+export function BootstrapVueResolver(_options: BootstrapVueResolverOptions = {}): ComponentResolver[] {
+  const options = { directives: true, ..._options }
+  const resolvers: ComponentResolver[] = [{
     type: 'component',
-    resolve: (name: string) => {
-      if (name.match(/^B[A-Z]/))
-        return { name, from: 'bootstrap-vue' }
+    resolve: (name) => {
+      if (name.match(/^B[A-Z]/)) {
+        return {
+          name: COMPONENT_ALIASES[name] || name,
+          from: 'bootstrap-vue',
+        }
+      }
     },
+  }]
+
+  if (options.directives) {
+    resolvers.push({
+      type: 'directive',
+      resolve: (name) => {
+        if (options.directives && name.match(/^B[A-Z]/)) {
+          return {
+            name: `V${name}`,
+            from: 'bootstrap-vue',
+          }
+        }
+      },
+    })
   }
+
+  return resolvers
 }


### PR DESCRIPTION
This PR adds support for BootstrapVue component aliases and directives (`options.directives: boolean` - default: `true`). 

The BootstrapVue resolver has also been added to the `README.md` and the list of supported resolvers has been reordered by name. I can revert these changes if I you don't want the `README.md` updates as part of this PR.

FYI @BenediktHeinrichs - I'm curious to know why [you stopped using it](https://git.rwth-aachen.de/coscine/frontend/apps/ui/-/merge_requests/74/diffs?commit_id=c8c53cdd1f120b82a3e78c5417a79863d262d4b7) in the project you mentioned?