### PR TITLE
feat(element-plus): add noStylesComponents for resolver options

### DIFF
--- a/src/core/resolvers/element-plus.ts
+++ b/src/core/resolvers/element-plus.ts
@@ -33,6 +33,11 @@ export interface ElementPlusResolverOptions {
    * exclude component name, if match do not resolve the name
    */
   exclude?: RegExp
+
+  /**
+   * a list of component names that have no styles, so resolving their styles file should be prevented
+   */
+  noStylesComponents?: string[]
 }
 
 type ElementPlusResolverOptionsResolved = Required<Omit<ElementPlusResolverOptions, 'exclude'>> &
@@ -145,7 +150,7 @@ function resolveDirective(name: string, options: ElementPlusResolverOptionsResol
   }
 }
 
-const noStylesComponent = ['ElAutoResizer']
+const noStylesComponents = ['ElAutoResizer']
 
 /**
  * Resolver for Element Plus
@@ -171,6 +176,7 @@ export function ElementPlusResolver(
       importStyle: 'css',
       directives: true,
       exclude: undefined,
+      noStylesComponents: options.noStylesComponents || [],
       ...options,
     }
     return optionsResolved
@@ -182,7 +188,7 @@ export function ElementPlusResolver(
       resolve: async (name: string) => {
         const options = await resolveOptions()
 
-        if (noStylesComponent.includes(name))
+        if ([...options.noStylesComponents, ...noStylesComponents].includes(name))
           return resolveComponent(name, { ...options, importStyle: false })
         else return resolveComponent(name, options)
       },


### PR DESCRIPTION
### Description

With the release of new versions of Element Plus, it is possible that components that do not have their own style files may appear, which causes an error when trying to resolve non-existent style files. Right now, there seems to be only one such component: `ElAutoResizer`. It has been fixed in https://github.com/antfu/unplugin-vue-components/pull/468
At the same time would be handy for getting around such blocking cases quickly without having to wait for a new release of `unplugin-vue-components`.
On the other hand, it seems useful to keep a list of already known components without styles inside the resolver. 
In this PR I suggest combining support for both options.

### Linked Issues

https://github.com/element-plus/element-plus/issues/7933
