### PR TITLE
feat: compatible with plugin-vue-jsx

### DIFF
--- a/src/core/transforms/component.ts
+++ b/src/core/transforms/component.ts
@@ -29,7 +29,10 @@ const resolveVue2 = (code: string, s: MagicString) => {
 const resolveVue3 = (code: string, s: MagicString) => {
   const results: ResolveResult[] = []
 
-  for (const match of code.matchAll(/_resolveComponent\("(.+?)"\)/g)) {
+  /**
+   * when using some plugin like plugin-vue-jsx, resolveComponent will be imported as resolveComponent1 to avoid duplicate import
+   */
+  for (const match of code.matchAll(/_resolveComponent[0-9]*\("(.+?)"\)/g)) {
     const matchedName = match[1]
     if (match.index != null && matchedName && !matchedName.startsWith('_')) {
       const start = match.index


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In SFC, When using some plugin like plugin-vue-jsx, resolveComponent will be imported as _resolveComponent1 to avoid duplicate import. Change the RegExp `/_resolveComponent\("(.+?)"\)/g ` to `/_resolveComponent[0-9]*\("(.+?)"\)/g` so that the component in jsx can be imported normally.

In fact, when you using a jsx file or runing vite in dev mode, it is also normal, but build mode is not.This may be confusing and cause bug. So I think it's necessary to fix it.


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
