### PR TITLE
fix: get vue version in esm version

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,4 +1,5 @@
 import { join, resolve } from 'path'
+import { createRequire } from 'module'
 import { slash, toArray } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import type { ComponentResolver, ComponentResolverObject, Options, ResolvedOptions } from '../types'
@@ -75,10 +76,10 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
   return resolved
 }
 
+const _require = createRequire(import.meta.url)
 function getVueVersion() {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const vue = require('vue')
+    const vue = _require('vue')
     const version = vue?.default?.version || vue?.version || '3'
     return version.startsWith('2.') ? 'vue2' : 'vue3'
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When ` "type": "module"`, `require` is not working.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
