### PR TITLE
fix: remove import.meta

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -4,6 +4,7 @@ import { slash, toArray } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import type { ComponentResolver, ComponentResolverObject, Options, ResolvedOptions } from '../types'
 import { detectTypeImports } from './type-imports/detect'
+import { getFileUrl } from './utils'
 
 export const defaultOptions: Omit<Required<Options>, 'include' | 'exclude' | 'transformer' | 'globs' | 'directives' | 'types'> = {
   dirs: 'src/components',
@@ -76,7 +77,7 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
   return resolved
 }
 
-const _require = typeof require === 'undefined' ? createRequire(import.meta.url) : require
+const _require = typeof require === 'undefined' ? createRequire(getFileUrl()) : require
 function getVueVersion() {
   try {
     const vue = _require('vue')

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -213,3 +213,14 @@ export function resolveImportPath(importName: string): string | undefined {
     preserveSymlinks: false,
   })
 }
+
+// @see https://jacobdeichert.ca/blog/2020/02/a-super-hacky-alternative-to-import-meta-url/
+export function getFileUrl() {
+  const stackTraceFrames = String(new Error('fake error').stack)
+    .replace(/^Error.*\n/, '')
+    .split('\n')
+
+  const callerFrame = stackTraceFrames[1]
+
+  return callerFrame.match(/file:.*\.m?js/)?.[0] ?? ''
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
fix `Cannot use 'import.meta' outside a module` error


### Linked Issues
#484 

### Additional context
The import.meta.url introduced by this PR https://github.com/antfu/unplugin-vue-components/commit/06293572aa7d59477d0d70e5acae03ccfca27f57 caused a breaking change 
