### PR TITLE
fix(bootstrap-vue): dropdown alias

### DIFF
--- a/src/core/resolvers/bootstrap-vue.ts
+++ b/src/core/resolvers/bootstrap-vue.ts
@@ -30,7 +30,7 @@ const COMPONENT_ALIASES: Record<string, string> = {
   BDdText: 'BDropdownText',
   BDropdownItemBtn: 'BDropdownItemButton',
   BFile: 'BFormFile',
-  BFormDatepicker: 'BDatepicker',
+  BDatepicker: 'BFormDatepicker',
   BInput: 'BFormInput',
   BNavDd: 'BNavItemDropdown',
   BNavDropdown: 'BNavItemDropdown',


### PR DESCRIPTION
### Description

BootstrapVue alias for date picker was reversed :

--> https://github.com/bootstrap-vue/bootstrap-vue/blob/dev/src/components/form-datepicker/index.js