### PR TITLE
feat(antdv): add option to support rename package

### DIFF
--- a/src/core/resolvers/antdv.ts
+++ b/src/core/resolvers/antdv.ts
@@ -193,6 +193,11 @@ export interface AntDesignVueResolverOptions {
    * use commonjs build default false
    */
   cjs?: boolean
+
+  /**
+   * rename package
+   */
+  packageName?: string
 }
 
 function getStyleDir(compName: string): string {
@@ -220,14 +225,15 @@ function getSideEffects(compName: string, options: AntDesignVueResolverOptions):
   if (!importStyle)
     return
   const lib = options.cjs ? 'lib' : 'es'
+  const packageName = options?.packageName || 'ant-design-vue'
 
   if (importStyle === 'less' || importLess) {
     const styleDir = getStyleDir(compName)
-    return `ant-design-vue/${lib}/${styleDir}/style`
+    return `${packageName}/${lib}/${styleDir}/style`
   }
   else {
     const styleDir = getStyleDir(compName)
-    return `ant-design-vue/${lib}/${styleDir}/style/css`
+    return `${packageName}/${lib}/${styleDir}/style/css`
   }
 }
 const primitiveNames = ['Affix', 'Anchor', 'AnchorLink', 'AutoComplete', 'AutoCompleteOptGroup', 'AutoCompleteOption', 'Alert', 'Avatar', 'AvatarGroup', 'BackTop', 'Badge', 'BadgeRibbon', 'Breadcrumb', 'BreadcrumbItem', 'BreadcrumbSeparator', 'Button', 'ButtonGroup', 'Calendar', 'Card', 'CardGrid', 'CardMeta', 'Collapse', 'CollapsePanel', 'Carousel', 'Cascader', 'Checkbox', 'CheckboxGroup', 'Col', 'Comment', 'ConfigProvider', 'DatePicker', 'MonthPicker', 'WeekPicker', 'RangePicker', 'QuarterPicker', 'Descriptions', 'DescriptionsItem', 'Divider', 'Dropdown', 'DropdownButton', 'Drawer', 'Empty', 'Form', 'FormItem', 'FormItemRest', 'Grid', 'Input', 'InputGroup', 'InputPassword', 'InputSearch', 'Textarea', 'Image', 'ImagePreviewGroup', 'InputNumber', 'Layout', 'LayoutHeader', 'LayoutSider', 'LayoutFooter', 'LayoutContent', 'List', 'ListItem', 'ListItemMeta', 'Menu', 'MenuDivider', 'MenuItem', 'MenuItemGroup', 'SubMenu', 'Mentions', 'MentionsOption', 'Modal', 'Statistic', 'StatisticCountdown', 'PageHeader', 'Pagination', 'Popconfirm', 'Popover', 'Progress', 'Radio', 'RadioButton', 'RadioGroup', 'Rate', 'Result', 'Row', 'Select', 'SelectOptGroup', 'SelectOption', 'Skeleton', 'SkeletonButton', 'SkeletonAvatar', 'SkeletonInput', 'SkeletonImage', 'Slider', 'Space', 'Spin', 'Steps', 'Step', 'Switch', 'Table', 'TableColumn', 'TableColumnGroup', 'TableSummary', 'TableSummaryRow', 'TableSummaryCell', 'Transfer', 'Tree', 'TreeNode', 'DirectoryTree', 'TreeSelect', 'TreeSelectNode', 'Tabs', 'TabPane', 'Tag', 'CheckableTag', 'TimePicker', 'TimeRangePicker', 'Timeline', 'TimelineItem', 'Tooltip', 'Typography', 'TypographyLink', 'TypographyParagraph', 'TypographyText', 'TypographyTitle', 'Upload', 'UploadDragger', 'LocaleProvider']
@@ -269,8 +275,8 @@ export function AntDesignVueResolver(options: AntDesignVueResolverOptions = {
 
       if (isAntdv(name) && !options?.exclude?.includes(name)) {
         const importName = name.slice(1)
-        const { cjs = false } = options
-        const path = `ant-design-vue/${cjs ? 'lib' : 'es'}`
+        const { cjs = false, packageName = 'ant-design-vue' } = options
+        const path = `${packageName}/${cjs ? 'lib' : 'es'}`
         return {
           name: importName,
           from: path,


### PR DESCRIPTION
### Description

support rename package when use it in the private NPM registry

### Linked Issues

[496](https://github.com/antfu/unplugin-vue-components/issues/496)
