### PR TITLE
docs: add note on default import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ build({
 Use components in templates as you would usually do, it will import components on demand, and there is no `import` and `component registration` required anymore! If you register the parent component asynchronously (or lazy route), the auto-imported components will be code-split along with their parent.
 
 > **Note**
-> that by default this plugin will only import components from the `src/components` path, you customize this using the `dirs` property in the plugin options.
+> that by default this plugin will import components from the `src/components` path. You can customize this using the `dirs` property in the plugin options.
 
 It will automatically turn this
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ build({
 
 Use components in templates as you would usually do, it will import components on demand, and there is no `import` and `component registration` required anymore! If you register the parent component asynchronously (or lazy route), the auto-imported components will be code-split along with their parent.
 
+> **Note**
+> that by default this plugin will only import components from the `src/components` path, you customize this using the `dirs` property in the plugin options.
+
 It will automatically turn this
 
 ```html

--- a/README.md
+++ b/README.md
@@ -127,9 +127,6 @@ build({
 
 Use components in templates as you would usually do, it will import components on demand, and there is no `import` and `component registration` required anymore! If you register the parent component asynchronously (or lazy route), the auto-imported components will be code-split along with their parent.
 
-> **Note**
-> that by default this plugin will import components from the `src/components` path. You can customize this using the `dirs` property in the plugin options.
-
 It will automatically turn this
 
 ```html
@@ -166,6 +163,8 @@ export default {
 }
 </script>
 ```
+> **Note**
+> that by default this plugin will import components from the `src/components` path. You can customize this using the `dirs` property in the plugin options.
 
 ## TypeScript
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ export default {
 </script>
 ```
 > **Note**
-> that by default this plugin will import components from the `src/components` path. You can customize this using the `dirs` property in the plugin options.
+> By default this plugin will import components in the `src/components` path. You can customize it using the `dirs` option.
 
 ## TypeScript
 


### PR DESCRIPTION
Following the "Usage" section in the docs, I tried to use this plugin and spent like half an hour trying to figure out why it's not working.
At first glance it looked very simple to use. Little I knew that it actually only import components from a specific path set by `dirs` option. Which I had to change according to my project structure.

So I added a little note so new users can have a heads up about the default path.