### PR TITLE
feat(arco): add iconPrefix option for arco resolver

### DIFF
--- a/test/resolvers/arco.test.ts
+++ b/test/resolvers/arco.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest'
+import { ArcoResolver } from '../../src/resolvers'
+
+import type { ComponentResolveResult, ComponentResolverObject } from '../../src'
+
+function testNoIconComponentResolve(resolver: ComponentResolverObject) {
+  expect(resolver.resolve('AButton')).toEqual<ComponentResolveResult>({
+    name: 'Button',
+    from: '@arco-design/web-vue',
+    sideEffects: '@arco-design/web-vue/es/button/style/css.js',
+  })
+}
+
+describe('ArcoResolver', () => {
+  test('Resolve component except icon', async () => {
+    const resolver = ArcoResolver() as ComponentResolverObject
+    expect(typeof resolver).toEqual('object')
+    testNoIconComponentResolve(resolver)
+    expect(resolver.resolve('IconStar')).toBeFalsy()
+  })
+
+  test('Can resolve icon component', () => {
+    const resolver = ArcoResolver({ resolveIcons: true }) as ComponentResolverObject
+    testNoIconComponentResolve(resolver)
+    expect(resolver.resolve('IconStar')).toEqual<ComponentResolveResult>({
+      name: 'IconStar',
+      from: '@arco-design/web-vue/es/icon',
+      as: 'IconStar',
+    })
+  })
+
+  test('Can resolve icon component with custom icon prefix', () => {
+    const resolver = ArcoResolver({ resolveIcons: { enable: true, iconPrefix: 'arco' } }) as ComponentResolverObject
+    testNoIconComponentResolve(resolver)
+    expect(resolver.resolve('ArcoIconStar')).toEqual<ComponentResolveResult>({
+      name: 'IconStar',
+      from: '@arco-design/web-vue/es/icon',
+      as: 'ArcoIconStar',
+    })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`Icon` of `ArcoDesign` support config `iconPrefix`, but `ArcoResolver` not supports. 

 this PR add the new option to support config `iconPrefix` for `arco`

