### PR TITLE
fix(prime-vue): add missing row component

### DIFF
--- a/src/core/resolvers/prime-vue.ts
+++ b/src/core/resolvers/prime-vue.ts
@@ -64,6 +64,7 @@ const components = [
   'ProgressSpinner',
   'RadioButton',
   'Rating',
+  'Row',
   'ScrollPanel',
   'ScrollTop',
   'SelectButton',


### PR DESCRIPTION
### Description

The PrimeVue resolver was missing an entry for row, so the Row component could not be used.

### Linked Issues

An issue is more work than a PR,, so no linked issue.

### Additional context

Would it make more sense to use the exclusion option by default? Then this needs to be reworked, but the current implementation seems a bit clunky.
