### PR TITLE
fix: use `globs` option cannot resolve index.vue

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -111,7 +111,7 @@ export function stringifyComponentImport({ as: name, from: path, name: importNam
 }
 
 export function getNameFromFilePath(filePath: string, options: ResolvedOptions): string {
-  const { resolvedDirs, directoryAsNamespace, globalNamespaces, collapseSamePrefixes } = options
+  const { resolvedDirs, directoryAsNamespace, globalNamespaces, collapseSamePrefixes, root } = options
 
   const parsedFilePath = parse(slash(filePath))
 
@@ -130,6 +130,10 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
 
   // set parent directory as filename if it is index
   if (filename === 'index' && !directoryAsNamespace) {
+    // when use `globs` option, `resolvedDirs` will always empty, and `folders` will also empty
+    if (isEmpty(folders))
+      folders = parsedFilePath.dir.slice(root.length + 1).split('/').filter(Boolean)
+
     filename = `${folders.slice(-1)[0]}`
     return filename
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Directory structure:
```
- src
  - components
    - dir-a
      - index.vue
    - dir-b
      - index.vue
```

Configs:
```ts
{
  plugins: [
    Components({
        allowOverrides: true,
        dts: 'src/components.d.ts',
        globs: ['src/components/**/index.vue']
    }),
  ]
}
```

When use `globs` option, `resolvedDirs` will always empty, and `folders` will also empty

https://github.com/antfu/unplugin-vue-components/blob/0c9131cd8f34d50f9d9b885b54ead6ae36657d53/src/core/options.ts#L33-L38

https://github.com/antfu/unplugin-vue-components/blob/0c9131cd8f34d50f9d9b885b54ead6ae36657d53/src/core/utils.ts#L120-L135

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
