### PR TITLE
varlet-ui组件自动导入样式，添加ImagePreview

### DIFF
--- a/src/core/resolvers/varlet-ui.ts
+++ b/src/core/resolvers/varlet-ui.ts
@@ -42,7 +42,7 @@ export interface VarletUIResolverOptions {
   importLess?: boolean
 }
 
-const varFunctions = ['Snackbar', 'Picker', 'ActionSheet', 'Dialog', 'Locale', 'StyleProvider']
+const varFunctions = ['ImagePreview', 'Snackbar', 'Picker', 'ActionSheet', 'Dialog', 'Locale', 'StyleProvider']
 const varDirectives = ['Ripple', 'Lazy']
 
 export function getResolved(name: string, options: VarletUIResolverOptions): ComponentResolveResult {


### PR DESCRIPTION
`varlet-ui`组件库，组件`ImagePreview`
https://varlet.gitee.io/varlet-ui/#/zh-CN/image-preview


### Description

`vite`+`vue3`项目中，`varlet-ui`组件库不能自动导入组件`ImagePreview`
```typescript
// vite.config.ts
import autoImport from 'unplugin-auto-import/vite';
import { VarletUIResolver } from 'unplugin-vue-components/resolvers';

export default defineConfig({
  plugins: [
    autoImport({
      resolvers: [VarletUIResolver({ autoImport: true })],
      eslintrc: { enabled: true },
    })
  ]
});
```

### Linked Issues


### Additional context

可以通过下面配置暂时解决：
```typescript
// vite.config.ts
import autoImport from 'unplugin-auto-import/vite';
import { VarletUIResolver, getResolved } from 'unplugin-vue-components/resolvers';

export default defineConfig({
  plugins: [
    autoImport({
      resolvers: [
        VarletUIResolver({ autoImport: true }),
        [(name: string) => (name === 'ImagePreview' ? getResolved('ImagePreview', { autoImport: true }) : undefined)]
      ],
      eslintrc: { enabled: true },
    })
  ]
});
```
