### PR TITLE
feat: compatible with @vitejs/plugin-vue2-jsx

### DIFF
--- a/src/core/transforms/component.ts
+++ b/src/core/transforms/component.ts
@@ -9,16 +9,14 @@ const debug = Debug('unplugin-vue-components:transform:component')
 
 const resolveVue2 = (code: string, s: MagicString) => {
   const results: ResolveResult[] = []
-
-  for (const match of code.matchAll(/[(_c)h]\([\s\n\t]*['"](.+?)["']([,)])/g)) {
-    const [full, matchedName, append] = match
-
+  for (const match of code.matchAll(/(_c|h)\([\s\n\t]*['"](.+?)["']([,)])/g)) {
+    const [full, renderFunctionName, matchedName, append] = match
     if (match.index != null && matchedName && !matchedName.startsWith('_')) {
       const start = match.index
       const end = start + full.length
       results.push({
         rawName: matchedName,
-        replace: resolved => s.overwrite(start, end, `${full.split('(')[0]}(${resolved}${append}`),
+        replace: resolved => s.overwrite(start, end, `${renderFunctionName}(${resolved}${append}`),
       })
     }
   }

--- a/src/core/transforms/component.ts
+++ b/src/core/transforms/component.ts
@@ -10,7 +10,7 @@ const debug = Debug('unplugin-vue-components:transform:component')
 const resolveVue2 = (code: string, s: MagicString) => {
   const results: ResolveResult[] = []
 
-  for (const match of code.matchAll(/_c\([\s\n\t]*['"](.+?)["']([,)])/g)) {
+  for (const match of code.matchAll(/[(_c)h]\([\s\n\t]*['"](.+?)["']([,)])/g)) {
     const [full, matchedName, append] = match
 
     if (match.index != null && matchedName && !matchedName.startsWith('_')) {
@@ -18,7 +18,7 @@ const resolveVue2 = (code: string, s: MagicString) => {
       const end = start + full.length
       results.push({
         rawName: matchedName,
-        replace: resolved => s.overwrite(start, end, `_c(${resolved}${append}`),
+        replace: resolved => s.overwrite(start, end, `${full.split('(')[0]}(${resolved}${append}`),
       })
     }
   }

--- a/src/core/transforms/component.ts
+++ b/src/core/transforms/component.ts
@@ -9,7 +9,7 @@ const debug = Debug('unplugin-vue-components:transform:component')
 
 const resolveVue2 = (code: string, s: MagicString) => {
   const results: ResolveResult[] = []
-  for (const match of code.matchAll(/(_c|h)\([\s\n\t]*['"](.+?)["']([,)])/g)) {
+  for (const match of code.matchAll(/\b(_c|h)\([\s\n\t]*['"](.+?)["']([,)])/g)) {
     const [full, renderFunctionName, matchedName, append] = match
     if (match.index != null && matchedName && !matchedName.startsWith('_')) {
       const start = match.index

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -86,6 +86,23 @@ this.$options.directives[\\"loading\\"] = __unplugin_directives_0;
 }
 `;
 
+exports[`transform > vue2 transform with jsx should work 1`] = `
+{
+  "code": "/* unplugin-vue-components disabled */import __unplugin_components_0 from 'test/component/TestComp';
+
+    export default {
+      render(){
+        return h(__unplugin_components_0, {
+        directives: [
+          { name: \\"loading\\", rawName: \\"v-loading\\", value: 123, expression: \\"123\\" }
+        ]
+      })
+      }
+    }
+    ",
+}
+`;
+
 exports[`transform > vue3 transform should work 1`] = `
 {
   "code": "/* unplugin-vue-components disabled */import __unplugin_directives_0 from 'test/directive/Loading';

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -40,6 +40,28 @@ describe('transform', () => {
     expect(await ctx.transform(code, '')).toMatchSnapshot()
   })
 
+  it('vue2 transform with jsx should work', async () => {
+    const code = `
+    export default {
+      render(){
+        return h("test-comp", {
+        directives: [
+          { name: "loading", rawName: "v-loading", value: 123, expression: "123" }
+        ]
+      })
+      }
+    }
+    `
+
+    const ctx = new Context({
+      resolvers: [resolver],
+      transformer: 'vue2',
+      directives: true,
+    })
+    ctx.sourcemap = false
+    expect(await ctx.transform(code, '')).toMatchSnapshot()
+  })
+
   it('vue3 transform should work', async () => {
     const code = `
     const render = (_ctx, _cache) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->


### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When use `@vitejs/plugin-vue2-jsx` to transform jsx code, this plugin will not generate tag code in jsx file.

For example: 

```
export default {
  render(){
    return (
       <some-tag/>
    )
  }
}
```
`@vitejs/plugin-vue2-jsx` will generate this code into 

```
export default {
render(){
return h("some-tag")
}
}
```

unplugin's `resolveVue2` function's [RegExp](https://github.com/antfu/unplugin-vue-components/blob/90b549d0080ed2591edba477187c7171853341e9/src/core/transforms/component.ts#L13)
will not generate `h` function which generated by `@vitejs/plugin-vue2-jsx`.

This PR change the `resolveVue2`'s RegExp to make sure unplugin will read the h function.


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This RegExp looks have a problem.
It will match `c` not `_c`. and i don't know how to make the new RegExp match `_c`.but in my project, i test it(`_c` or `c`) has no difference.
