### PR TITLE
fix(collapseSamePrefixes): missing collapse when prefix did not match from beginning

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "prettier.enable": false
 }

--- a/README.md
+++ b/README.md
@@ -338,7 +338,12 @@ Components({
 
   // Allow subdirectories as namespace prefix for components.
   directoryAsNamespace: false,
-  // Subdirectory paths for ignoring namespace prefixes
+
+  // Collapse same prefixes (camel-sensitive) of folders and components
+  // to prevent duplication inside namespaced component name.
+  // works when `directoryAsNamespace: true`
+  collapseSamePrefixes: false,
+  // Subdirectory paths for ignoring namespace prefixes.
   // works when `directoryAsNamespace: true`
   globalNamespaces: [],
 

--- a/examples/vite-vue3/src/components/collapse/collapseFolder/CollapseFolderAndComponentFromRoot.vue
+++ b/examples/vite-vue3/src/components/collapse/collapseFolder/CollapseFolderAndComponentFromRoot.vue
@@ -1,0 +1,9 @@
+<script>
+export default {
+  name: 'CollapseFolderAndComponentFromRoot',
+}
+</script>
+
+<template>
+  <h3>CollapseFolderAndComponentFromRoot Component: <code>collapse/collapseFolder/CollapseFolderAndComponentFromRoot.vue</code></h3>
+</template>

--- a/examples/vite-vue3/src/components/collapse/collapseFolder/FolderAndComponentPartially.vue
+++ b/examples/vite-vue3/src/components/collapse/collapseFolder/FolderAndComponentPartially.vue
@@ -1,0 +1,9 @@
+<script>
+export default {
+  name: 'FolderAndComponentPartially',
+}
+</script>
+
+<template>
+  <h3>FolderAndComponentPartially Component: <code>collapse/collapseFolder/FolderAndComponentPartially.vue</code></h3>
+</template>

--- a/examples/vite-vue3/src/components/collapse/collapseFolderAnd/CollapseFolderAndComponentPrefixes.vue
+++ b/examples/vite-vue3/src/components/collapse/collapseFolderAnd/CollapseFolderAndComponentPrefixes.vue
@@ -1,9 +1,0 @@
-<script>
-export default {
-  name: 'CollapseFolderAndComponentPrefixes',
-}
-</script>
-
-<template>
-  <h3>CollapseFolderAndComponentPrefixes Component: <code>collapse/collapseFolderAnd/CollapseFolderAndComponentPrefixes.vue</code></h3>
-</template>

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -156,18 +156,24 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
         const collapsed: string[] = []
 
         for (const fileOrFolderName of namespaced) {
-          const collapsedFilename = collapsed.join('')
-          if (
-            collapsedFilename
-            && fileOrFolderName.toLowerCase().startsWith(collapsedFilename.toLowerCase())
-          ) {
-            const collapseSamePrefix = fileOrFolderName.slice(collapsedFilename.length)
+          let cumulativePrefix = ''
+          let didCollapse = false
 
-            collapsed.push(collapseSamePrefix)
-            continue
+          for (const parentFolder of [...collapsed].reverse()) {
+            cumulativePrefix = `${capitalize(parentFolder)}${cumulativePrefix}`
+
+            if (pascalCase(fileOrFolderName).startsWith(pascalCase(cumulativePrefix))) {
+              const collapseSamePrefix = fileOrFolderName.slice(cumulativePrefix.length)
+
+              collapsed.push(collapseSamePrefix)
+
+              didCollapse = true
+              break
+            }
           }
 
-          collapsed.push(fileOrFolderName)
+          if (!didCollapse)
+            collapsed.push(fileOrFolderName)
         }
 
         namespaced = collapsed

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,8 +103,8 @@ export interface Options {
   directoryAsNamespace?: boolean
 
   /**
-   * Collapse same prefixes (case-insensitive) of folders and components
-   * to prevent duplication inside namespaced component name
+   * Collapse same prefixes (camel-sensitive) of folders and components
+   * to prevent duplication inside namespaced component name.
    *
    * Works when `directoryAsNamespace: true`
    * @default false

--- a/test/__snapshots__/search.test.ts.snap
+++ b/test/__snapshots__/search.test.ts.snap
@@ -11,8 +11,12 @@ exports[`search > should with namespace & collapse 1`] = `
     "from": "src/components/book/index.vue",
   },
   {
-    "as": "CollapseFolderAndComponentPrefixes",
-    "from": "src/components/collapse/collapseFolderAnd/CollapseFolderAndComponentPrefixes.vue",
+    "as": "CollapseFolderAndComponentFromRoot",
+    "from": "src/components/collapse/collapseFolder/CollapseFolderAndComponentFromRoot.vue",
+  },
+  {
+    "as": "CollapseFolderAndComponentPartially",
+    "from": "src/components/collapse/collapseFolder/FolderAndComponentPartially.vue",
   },
   {
     "as": "ComponentA",
@@ -60,8 +64,12 @@ exports[`search > should with namespace 1`] = `
     "from": "src/components/book/index.vue",
   },
   {
-    "as": "CollapseCollapseFolderAndCollapseFolderAndComponentPrefixes",
-    "from": "src/components/collapse/collapseFolderAnd/CollapseFolderAndComponentPrefixes.vue",
+    "as": "CollapseCollapseFolderCollapseFolderAndComponentFromRoot",
+    "from": "src/components/collapse/collapseFolder/CollapseFolderAndComponentFromRoot.vue",
+  },
+  {
+    "as": "CollapseCollapseFolderFolderAndComponentPartially",
+    "from": "src/components/collapse/collapseFolder/FolderAndComponentPartially.vue",
   },
   {
     "as": "ComponentA",
@@ -117,8 +125,8 @@ exports[`search > should work 1`] = `
     "from": "src/components/ui/nested/checkbox.vue",
   },
   {
-    "as": "CollapseFolderAndComponentPrefixes",
-    "from": "src/components/collapse/collapseFolderAnd/CollapseFolderAndComponentPrefixes.vue",
+    "as": "CollapseFolderAndComponentFromRoot",
+    "from": "src/components/collapse/collapseFolder/CollapseFolderAndComponentFromRoot.vue",
   },
   {
     "as": "ComponentA",
@@ -139,6 +147,10 @@ exports[`search > should work 1`] = `
   {
     "as": "ComponentD",
     "from": "src/components/ComponentD.vue",
+  },
+  {
+    "as": "FolderAndComponentPartially",
+    "from": "src/components/collapse/collapseFolder/FolderAndComponentPartially.vue",
   },
   {
     "as": "Recursive",


### PR DESCRIPTION
### Description

The previous implementation only compared prefixes of files/folders with all previous names at once.
Now, the algorithm walks incrementally from the previous folder name to try to find a prefix match.

Prefix matcher implementation:
```
Previous:
A/B/C/X -> X.startsWith("ABC")?

New:
A/B/C/X -> X.startsWith("C"), X.startsWith("BC"), X.startsWith("ABC)?
```

Also updated and added missing docs in README.

### Linked Issues

Fixes #546 

### Additional context

The algorithm is now O(n^2) but folder depths of components are not as deep as to cause trouble (hopefully).