### PR TITLE
fix: add ";"  when generate Typescript interface item string in declaration.ts

### DIFF
--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -134,13 +134,13 @@ ${head}`
   if (Object.keys(declarations.component).length > 0) {
     code += `
   export interface GlobalComponents {
-    ${declarations.component.join('\n    ')}
+    ${declarations.component.join(';\n    ')}
   }`
   }
   if (Object.keys(declarations.directive).length > 0) {
     code += `
   export interface ComponentCustomProperties {
-    ${declarations.directive.join('\n    ')}
+    ${declarations.directive.join(';\n    ')}
   }`
   }
   code += '\n}\n'


### PR DESCRIPTION
The plugin generate .d.ts file  missed interface item decollator:

![image](https://user-images.githubusercontent.com/37231473/218421508-ab509638-20f0-4df0-b9b5-d4916b01a282.png)

According to the syntax of TS, there should be an ';' between each interface item;

![image](https://user-images.githubusercontent.com/37231473/218422009-3724dc24-bc03-447e-853e-3e7cc1d40f3a.png)
