### PR TITLE
feat: tdesign no need import sideEffects

### DIFF
--- a/src/core/resolvers/tdesign.ts
+++ b/src/core/resolvers/tdesign.ts
@@ -2,12 +2,6 @@ import type { ComponentResolver } from '../../types'
 
 export interface TDesignResolverOptions {
   /**
-   * import style along with components
-   * @default 'css'
-   */
-  importStyle?: boolean | 'css' | 'less'
-
-  /**
    * select the specified library
    * @default 'vue'
    */

--- a/src/core/resolvers/tdesign.ts
+++ b/src/core/resolvers/tdesign.ts
@@ -1,5 +1,4 @@
-import type { ComponentResolver, SideEffectsInfo } from '../../types'
-import { kebabCase } from '../utils'
+import type { ComponentResolver } from '../../types'
 
 export interface TDesignResolverOptions {
   /**
@@ -33,69 +32,6 @@ export interface TDesignResolverOptions {
   exclude?: string | RegExp | (string | RegExp)[]
 }
 
-function getSideEffects(importName: string, options: TDesignResolverOptions): SideEffectsInfo | undefined {
-  const { library = 'vue', importStyle = 'css' } = options
-  let fileName = kebabCase(importName)
-
-  if (!importStyle)
-    return
-
-  if (['config-provider', 'icon'].includes(fileName))
-    return
-
-  if (fileName.includes('-') && fileName !== 'input-number') {
-    const prefix = fileName.slice(0, fileName.indexOf('-'))
-    const container = ['anchor', 'avatar', 'breadcrumb', 'checkbox', 'dropdown', 'form', 'input', 'list', 'menu', 'radio', 'slider', 'swiper', 'color-picker', 'text', 'collapse', 'timeline']
-
-    if (container.includes(prefix))
-      fileName = prefix
-  }
-
-  if (['row', 'col'].includes(fileName))
-    fileName = 'grid'
-
-  if (fileName === 'addon')
-    fileName = 'input'
-
-  if (['aside', 'layout', 'header', 'footer', 'content'].includes(fileName))
-    fileName = 'layout'
-
-  if (['head-menu', 'submenu'].includes(fileName))
-    fileName = 'menu'
-
-  if (['option', 'option-group'].includes(fileName))
-    fileName = 'select'
-
-  if (['tab-nav', 'tab-panel'].includes(fileName))
-    fileName = 'tabs'
-
-  if (fileName === 'step-item')
-    fileName = 'steps'
-
-  if (fileName === 'check-tag')
-    fileName = 'tag'
-
-  if (['time-range-picker', 'time-range-picker-panel', 'time-picker-panel'].includes(fileName))
-    fileName = 'time-picker'
-
-  if (['date-range-picker', 'date-range-picker-panel', 'date-picker-panel'].includes(fileName))
-    fileName = 'date-picker'
-
-  if (['color-picker', 'color-picker-panel'].includes(fileName))
-    fileName = 'color-picker'
-
-  if (['enhanced-table', 'base-table'].includes(fileName))
-    fileName = 'table'
-
-  if (['pagination-mini'].includes(fileName))
-    fileName = 'pagination'
-
-  if (importStyle === 'less')
-    return `tdesign-${library}/esm/${fileName}/style`
-
-  return `tdesign-${library}/es/${fileName}/style`
-}
-
 export function TDesignResolver(options: TDesignResolverOptions = {}): ComponentResolver {
   return {
     type: 'component',
@@ -119,7 +55,6 @@ export function TDesignResolver(options: TDesignResolverOptions = {}): Component
         return {
           name: importName,
           from: `tdesign-${library}${importFrom}`,
-          sideEffects: getSideEffects(importName, options),
         }
       }
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Tdesign no need import sideEffects. When import tdesign, it will import all css. So now it needn't import sideEffect


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
