### PR TITLE
feat: support rspack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ On-demand components auto importing for Vue.
 
 - 💚 Supports both Vue 2 and Vue 3 out-of-the-box.
 - ✨ Supports both components and directives.
-- ⚡️ Supports Vite, Webpack, Vue CLI, Rollup, esbuild and more, powered by <a href="https://github.com/unjs/unplugin">unplugin</a>.
+- ⚡️ Supports Vite, Webpack, Rspack, Vue CLI, Rollup, esbuild and more, powered by <a href="https://github.com/unjs/unplugin">unplugin</a>.
 - 🏝 Tree-shakable, only registers the components you use.
 - 🪐 Folder names as namespaces.
 - 🦾 Full TypeScript support.
@@ -75,6 +75,21 @@ module.exports = {
   /* ... */
   plugins: [
     require('unplugin-vue-components/webpack')({ /* options */ }),
+  ],
+}
+```
+
+<br></details>
+
+<details>
+<summary>Rspack</summary><br>
+
+```ts
+// rspack.config.js
+module.exports = {
+  /* ... */
+  plugins: [
+    require('unplugin-vue-components/rspack')({ /* options */ }),
   ],
 }
 ```

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
       "require": "./dist/webpack.js",
       "import": "./dist/webpack.mjs"
     },
+    "./rspack": {
+      "types": "./dist/rspack.d.ts",
+      "require": "./dist/rspack.js",
+      "import": "./dist/rspack.mjs"
+    },
     "./esbuild": {
       "types": "./dist/esbuild.d.ts",
       "require": "./dist/esbuild.js",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "magic-string": "^0.30.0",
     "minimatch": "^7.4.2",
     "resolve": "^1.22.1",
-    "unplugin": "^1.1.0"
+    "unplugin": "^1.3.1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
       rollup: ^3.18.0
       tsup: ^6.6.3
       typescript: ^4.9.5
-      unplugin: ^1.1.0
+      unplugin: ^1.3.1
       vite: ^4.1.4
       vitest: ^0.29.2
       vue: 3.2.45
@@ -46,7 +46,7 @@ importers:
       magic-string: 0.30.0
       minimatch: 7.4.2
       resolve: 1.22.1
-      unplugin: 1.1.0
+      unplugin: 1.3.1
     devDependencies:
       '@antfu/eslint-config': 0.36.0_ycpbpc6yetojsgtrx3mwntkhsu
       '@babel/parser': 7.21.2
@@ -9682,7 +9682,7 @@ packages:
       acorn: 8.8.2
       estree-walker: 3.0.3
       magic-string: 0.27.0
-      unplugin: 1.1.0
+      unplugin: 1.3.1
     dev: true
 
   /unicode-canonical-property-names-ecmascript/2.0.0:
@@ -9721,7 +9721,7 @@ packages:
       pkg-types: 1.0.2
       scule: 1.0.0
       strip-literal: 1.0.0
-      unplugin: 1.1.0
+      unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -9857,6 +9857,15 @@ packages:
 
   /unplugin/1.1.0:
     resolution: {integrity: sha512-I8obQ8Rs/hnkxokRV6g8JKOQFgYNnTd9DL58vcSt5IJ9AkK8wbrtsnzD5hi4BJlvcY536JzfEXj9L6h7j559/A==}
+    dependencies:
+      acorn: 8.8.2
+      chokidar: 3.5.3
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.5.0
+    dev: true
+
+  /unplugin/1.3.1:
+    resolution: {integrity: sha512-h4uUTIvFBQRxUKS2Wjys6ivoeofGhxzTe2sRWlooyjHXVttcVfV/JiavNd3d4+jty0SVV0dxGw9AkY9MwiaCEw==}
     dependencies:
       acorn: 8.8.2
       chokidar: 3.5.3

--- a/src/rspack.ts
+++ b/src/rspack.ts
@@ -1,0 +1,3 @@
+import unplugin from '.'
+
+export default unplugin.rspack


### PR DESCRIPTION
### Description

This PR adds an `rspack` export to the package, using unplugin's experimental [rspack](https://www.rspack.dev/) support. (For the purpose of adding this, it also had to update the `unplugin` dependency to the latest version.)

### Linked Issues

This has not been brought up yet.

### Additional context

Rspack just recently [added support](https://github.com/web-infra-dev/rspack/issues/2350) for vue-loader. As far as I have tested it, this works flawlessly. Having Vue support in Rspack was a good occasion to look for Rspack support in some popular build tools that commonly come with Vue projects.

For reference, here's also a basic proof of concept of a Vue app bundled by Rspack, using this PR's branch for registering components: https://github.com/loilo/rspack-vue-demo