### PR TITLE
refactor: ionic resolver strict components 

### DIFF
--- a/src/core/resolvers/ionic.ts
+++ b/src/core/resolvers/ionic.ts
@@ -1,16 +1,107 @@
 import type { ComponentResolver } from '../../types'
 
+/** 
+ * source: https://github.com/nuxt-modules/ionic/blob/main/src/imports.ts
+ * @author @danielroe
+ */
+export const IonicBuiltInComponents = [
+  'IonAccordion',
+  'IonAccordionGroup',
+  'IonActionSheet',
+  'IonAlert',
+  'IonApp',
+  'IonAvatar',
+  'IonBackButton',
+  'IonBackdrop',
+  'IonBadge',
+  'IonBreadcrumb',
+  'IonBreadcrumbs',
+  'IonButton',
+  'IonButtons',
+  'IonCard',
+  'IonCardContent',
+  'IonCardHeader',
+  'IonCardSubtitle',
+  'IonCardTitle',
+  'IonCheckbox',
+  'IonChip',
+  'IonCol',
+  'IonContent',
+  'IonDatetime',
+  'IonDatetimeButton',
+  'IonFab',
+  'IonFabButton',
+  'IonFabList',
+  'IonFooter',
+  'IonGrid',
+  'IonHeader',
+  'IonIcon',
+  'IonImg',
+  'IonInfiniteScroll',
+  'IonInfiniteScrollContent',
+  'IonInput',
+  'IonItem',
+  'IonItemDivider',
+  'IonItemGroup',
+  'IonItemOption',
+  'IonItemOptions',
+  'IonItemSliding',
+  'IonLabel',
+  'IonList',
+  'IonListHeader',
+  'IonLoading',
+  'IonMenu',
+  'IonMenuButton',
+  'IonMenuToggle',
+  'IonModal',
+  'IonNav',
+  'IonNavLink',
+  'IonNote',
+  'IonPage',
+  'IonPicker',
+  'IonPopover',
+  'IonProgressBar',
+  'IonRadio',
+  'IonRadioGroup',
+  'IonRange',
+  'IonRefresher',
+  'IonRefresherContent',
+  'IonReorder',
+  'IonReorderGroup',
+  'IonRippleEffect',
+  'IonRouterOutlet',
+  'IonRow',
+  'IonSearchbar',
+  'IonSegment',
+  'IonSegmentButton',
+  'IonSelect',
+  'IonSelectOption',
+  'IonSkeletonText',
+  'IonSpinner',
+  'IonSplitPane',
+  'IonTabBar',
+  'IonTabButton',
+  'IonTabs',
+  'IonText',
+  'IonTextarea',
+  'IonThumbnail',
+  'IonTitle',
+  'IonToast',
+  'IonToggle',
+  'IonToolbar',
+]
+
 /**
  * Resolver for ionic framework
  *
- * @author @mathsgod
- * @link https://github.com/mathsgod
+ * @author @mathsgod @reslear
+ * @link https://ionicframework.com/
  */
 export function IonicResolver(): ComponentResolver {
   return {
     type: 'component',
     resolve: (name: string) => {
-      if (name.startsWith('Ion')) {
+      if (IonicBuiltInComponents.includes(name)) {
         return {
           name,
           from: '@ionic/vue',


### PR DESCRIPTION
### Description

strict checking on Ionic components, better Ionic v7 support (excluding e.g. IonSlider, IonSlide and etc )
Based on https://github.com/nuxt-modules/ionic/blob/main/src/imports.ts by @danielroe

### Linked Issues
-

### Additional context

-
