### PR TITLE
fix(vite-vue3): update include regex to support production build

### DIFF
--- a/examples/vite-vue3/package.json
+++ b/examples/vite-vue3/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "cross-env DEBUG=unplugin-vue-components:* vite",
-    "build": "cross-env DEBUG=unplugin-vue-components:* vite build"
+    "build": "cross-env DEBUG=unplugin-vue-components:* vite build",
+    "preview": "cross-env DEBUG=unplugin-vue-components:* vite preview"
   },
   "dependencies": {
     "vant": "^4.6.2"

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -26,7 +26,7 @@ const config: UserConfig = {
       directoryAsNamespace: true,
       dts: true,
       globalNamespaces: ['global'],
-      include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
+      include: [/\.vue($|\?)/, /\.md($|\?)/],
       resolvers: [
         (name) => {
           if (name === 'MyCustom')

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -26,7 +26,7 @@ const config: UserConfig = {
       directoryAsNamespace: true,
       dts: true,
       globalNamespaces: ['global'],
-      include: [/\.vue$/, /\.md$/],
+      include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
       resolvers: [
         (name) => {
           if (name === 'MyCustom')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

problem: .The problem just belongs to examples/vite-vue3. There is no component in web page after running 'pnpm build' and 'pnpm preview'

process: After running 'pnpm build', the path '...ComponentA.vue' will become '...ComponentA.vue?vue&type=script&setup=true&lang.ts'. But vite config option 'include' do not include this situation. So I think it's time to change 'include' option's regex. The soluation case is the same as 'core/unplugin.ts'.

### Linked Issues
#503 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Although I soluation the probleam, I don't know the process that the path '...ComponentA.vue' will become '...ComponentA.vue?vue&type=script&setup=true&lang.ts'.
