### PR TITLE
fix: typo in `normalizeComponentInfo` method name

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -6,7 +6,7 @@ import type { UpdatePayload, ViteDevServer } from 'vite'
 import { slash, throttle, toArray } from '@antfu/utils'
 import type { ComponentInfo, Options, ResolvedOptions, Transformer } from '../types'
 import { DIRECTIVE_IMPORT_PREFIX } from './constants'
-import { getNameFromFilePath, matchGlobs, normalizeComponetInfo, parseId, pascalCase, resolveAlias } from './utils'
+import { getNameFromFilePath, matchGlobs, normalizeComponentInfo, parseId, pascalCase, resolveAlias } from './utils'
 import { resolveOptions } from './options'
 import { searchComponents } from './fs/glob'
 import { writeDeclaration } from './declaration'
@@ -239,7 +239,7 @@ export class Context {
       else {
         info = {
           as: name,
-          ...normalizeComponetInfo(result),
+          ...normalizeComponentInfo(result),
         }
       }
       if (type === 'component')

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -86,7 +86,7 @@ export function stringifyImport(info: ImportInfo | string) {
     return `import ${info.as} from '${info.from}'`
 }
 
-export function normalizeComponetInfo(info: ImportInfo | ImportInfoLegacy | ComponentInfo): ComponentInfo {
+export function normalizeComponentInfo(info: ImportInfo | ImportInfoLegacy | ComponentInfo): ComponentInfo {
   if ('path' in info) {
     return {
       from: info.path,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR renames `normalizeComponetInfo` to `normalizeComponentInfo`, it's just a typo.

### Additional context

[I searched github](https://github.com/search?q=normalizeComponetInfo&type=code) to find if someone imports normalizeComponetInfo, but didn't find any open sourced project, exept of forks of this project. So, I suppose, this won't affect anyone.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
