### PR TITLE
fix: when using glob with relative path get wrong component name

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -111,7 +111,7 @@ export function stringifyComponentImport({ as: name, from: path, name: importNam
 }
 
 export function getNameFromFilePath(filePath: string, options: ResolvedOptions): string {
-  const { resolvedDirs, directoryAsNamespace, globalNamespaces, collapseSamePrefixes, root } = options
+  const { resolvedDirs, directoryAsNamespace, globalNamespaces, collapseSamePrefixes } = options
 
   const parsedFilePath = parse(slash(filePath))
 
@@ -132,7 +132,7 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
   if (filename === 'index' && !directoryAsNamespace) {
     // when use `globs` option, `resolvedDirs` will always empty, and `folders` will also empty
     if (isEmpty(folders))
-      folders = parsedFilePath.dir.slice(root.length + 1).split('/').filter(Boolean)
+      folders = parsedFilePath.dir.split('/').filter(Boolean)
 
     filename = `${folders.slice(-1)[0]}`
     return filename

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -19,4 +19,14 @@ describe('getNameFromFilePath', () => {
     const inComponentFilePath = '/src/components/[a1]/b_2/c 3/d.4/[...ef]/ghi.vue'
     expect(getNameFromFilePath(inComponentFilePath, options as ResolvedOptions)).toBe('a1-b2-c3-d4-ef-ghi')
   })
+
+  it('file is out of root path and filename is index', () => {
+    const options: Partial<ResolvedOptions> = {
+      root: '/root/projects/website',
+      directoryAsNamespace: false,
+      resolvedDirs: [],
+    }
+    const inComponentFilePath = '/root/libs/ui/Button/index.vue'
+    expect(getNameFromFilePath(inComponentFilePath, options as ResolvedOptions)).toBe('Button')
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When using glob with relative path, get wrong component name for index.vue

Using pnpm init a monorepo project. Place UI components in /libs/ui, but run vite in project folder.

Project structure
```
floder
|--projects
     |--website
          |--vite.config.ts
|--libs
     |--ui
          |--Button
               |--index.vue
```

Config like this:
```
import Components from 'unplugin-vue-components/vite';

Components({
      globs: ['../../libs/ui/**/*.vue'],
}),
```
Got wrong component name: undefined.
