### PR TITLE
feat: add sourcemap configuration switch

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -39,6 +39,7 @@ export class Context {
     private rawOptions: Options,
   ) {
     this.options = resolveOptions(rawOptions, this.root)
+    this.sourcemap = rawOptions.sourcemap ?? true
     this.generateDeclaration = throttle(500, this._generateDeclaration.bind(this), { noLeading: false })
     this.setTransformer(this.options.transformer)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,6 +198,13 @@ export interface Options {
    * Vue version of project. It will detect automatically if not specified.
    */
   version?: 2 | 2.7 | 3
+
+  /**
+   * Generate sourcemap for the transformed code.
+   *
+   * @default true
+   */
+  sourcemap?: boolean
 }
 
 export type ResolvedOptions = Omit<


### PR DESCRIPTION
In a vue3+webpack project, referencing unplugin-vue-components/webpack will result in the code being compiled when debugging locally, as shown in the figure:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/e6352bba-efb0-47dd-8bb5-8a798f69d2fa" />

The normal debugger source code should be
<img width="603" alt="image" src="https://github.com/user-attachments/assets/8761b220-1259-4875-b4aa-9c0a8017a8cd" />

I guess if the sourcemap transformed by magic-string is directly used by webpack as the source code for secondary compilation
So, a socuremap switch configuration is added, with the default being true