### PR TITLE
fix(idux-resolver): update style path to index.css to correctly load styles in 2.0

### DIFF
--- a/src/core/resolvers/idux.ts
+++ b/src/core/resolvers/idux.ts
@@ -117,7 +117,7 @@ function getSideEffects(version: string, path: string, importStyle?: 'css' | 'le
   const styleRoot = `${path}/style`
   const themeRoot = `${path}/theme`
 
-  const styleImport = `${styleRoot}/${importStyle === 'css' ? 'index_css' : 'index'}`
+  const styleImport = `${styleRoot}/${importStyle === 'css' ? 'index.css' : 'index'}`
   if (!resolveModule(styleImport))
     return
 


### PR DESCRIPTION
…styles in 2.0

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix the style import path in IduxResolver for idux 2.0 components.
Previously the resolver used index_css, which does not exist in 2.0+, causing component styles to not be loaded correctly.
This change updates the path to index.css, ensuring styles are automatically imported in both development and production.

### Linked Issues


### Additional context

•	This affects all components using IduxResolver with importStyle: 'css'
•	No breaking changes for idux 1.x because legacy logic remains untouched
