### PR TITLE
Remove CommonJS support, ESM only

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ export default {
 
 ```ts
 // webpack.config.js
+// unplugin-vue-components removed support for CommonJS after version 29.1.0
 module.exports = {
   /* ... */
   plugins: [
@@ -101,6 +102,7 @@ module.exports = {
 
 ```ts
 // rspack.config.js
+// unplugin-vue-components removed support for CommonJS after version 29.1.0
 module.exports = {
   /* ... */
   plugins: [
@@ -122,6 +124,7 @@ You might not need this plugin for Nuxt. Use [`@nuxt/components`](https://github
 <summary>Vue CLI</summary><br>
 
 ```ts
+// unplugin-vue-components removed support for CommonJS after version 29.1.0
 // vue.config.js
 module.exports = {
   /* ... */

--- a/package.json
+++ b/package.json
@@ -14,49 +14,19 @@
   },
   "bugs": "https://github.com/unplugin/unplugin-vue-components/issues",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    },
-    "./nuxt": {
-      "import": "./dist/nuxt.js",
-      "require": "./dist/nuxt.cjs"
-    },
-    "./resolvers": {
-      "import": "./dist/resolvers.js",
-      "require": "./dist/resolvers.cjs"
-    },
-    "./rollup": {
-      "import": "./dist/rollup.js",
-      "require": "./dist/rollup.cjs"
-    },
-    "./rolldown": {
-      "import": "./dist/rolldown.js",
-      "require": "./dist/rolldown.cjs"
-    },
-    "./types": {
-      "import": "./dist/types.js",
-      "require": "./dist/types.cjs"
-    },
-    "./vite": {
-      "import": "./dist/vite.js",
-      "require": "./dist/vite.cjs"
-    },
-    "./webpack": {
-      "import": "./dist/webpack.js",
-      "require": "./dist/webpack.cjs"
-    },
-    "./rspack": {
-      "import": "./dist/rspack.js",
-      "require": "./dist/rspack.cjs"
-    },
-    "./esbuild": {
-      "import": "./dist/esbuild.js",
-      "require": "./dist/esbuild.cjs"
-    },
+    ".": "./dist/index.js",
+    "./nuxt": "./dist/nuxt.js",
+    "./resolvers": "./dist/resolvers.js",
+    "./rollup": "./dist/rollup.js",
+    "./rolldown": "./dist/rolldown.js",
+    "./types": "./dist/types.js",
+    "./vite": "./dist/vite.js",
+    "./webpack": "./dist/webpack.js",
+    "./rspack": "./dist/rspack.js",
+    "./esbuild": "./dist/esbuild.js",
     "./*": "./*"
   },
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "index.d.ts",
   "typesVersions": {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,5 +2,5 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['src/*.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The dependency [unplugin-utils](https://github.com/sxzz/unplugin-utils/blob/main/package.json) only supports ESM after 0.3.0. This removes CommonJS build output and exports.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
